### PR TITLE
fix:灵感助手生成字段未正确更新章节正文

### DIFF
--- a/backend/app/services/ai/assistant/tools.py
+++ b/backend/app/services/ai/assistant/tools.py
@@ -208,6 +208,7 @@ def create_card(
         
         # 5. 保存数据并标记为 AI 修改
         card.content = result["data"]
+        flag_modified(card, "content")
         card.ai_modified = True
         card.needs_confirmation = True
         card.last_modified_by = "ai"

--- a/backend/app/services/card_service.py
+++ b/backend/app/services/card_service.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Dict, Any
 from sqlmodel import Session, select
 from sqlalchemy.orm import joinedload
+from sqlalchemy.orm.attributes import flag_modified
 
 from app.db.models import Card, CardType, Project
 from app.schemas.card import CardCreate, CardUpdate, CardTypeCreate, CardTypeUpdate
@@ -352,6 +353,7 @@ class CardService:
         target[parts[-1]] = updated_value
         
         card.content = new_content
+        flag_modified(card, "content")
         self.db.add(card)
         self.db.commit()
         self.db.refresh(card)

--- a/backend/app/services/memory_service.py
+++ b/backend/app/services/memory_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 from sqlmodel import Session
+from sqlalchemy.orm.attributes import flag_modified
 
 from loguru import logger
 
@@ -433,6 +434,7 @@ class MemoryService:
                             item for item in model.dynamic_info[del_item.dynamic_type] if item.id != del_item.id
                         ]
                         card.content = model.model_dump(exclude_unset=True)
+                        flag_modified(card, "content")
                         self.session.add(card)
                 except Exception as e:
                     logger.warning(f"Failed to process deletion for {del_item.name}: {e}")
@@ -496,6 +498,7 @@ class MemoryService:
                         model.dynamic_info[cat] = existing_items[:limit]
 
                 card.content = model.model_dump(exclude_unset=True)
+                flag_modified(card, "content")
                 updated_cards[card.title] = card
             except Exception as e:
                 logger.warning(f"Failed to process addition for {info_group.name}: {e}")

--- a/backend/app/services/workflow/nodes/card/batch_upsert.py
+++ b/backend/app/services/workflow/nodes/card/batch_upsert.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, AsyncIterator, Union, TYPE_CHECKIN
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlmodel import select
+from sqlalchemy.orm.attributes import flag_modified
 
 if TYPE_CHECKING:
     from ...engine.async_executor import ProgressEvent
@@ -161,6 +162,7 @@ class CardBatchUpsertNode(BaseNode[CardBatchUpsertInput, CardBatchUpsertOutput])
                     if not isinstance(existing_card.content, dict):
                         existing_card.content = {}
                     existing_card.content.update(content)
+                    flag_modified(existing_card, "content")
                     updated = True
                 
                 # 如果父ID变化（移动）

--- a/backend/app/services/workflow/nodes/card/update.py
+++ b/backend/app/services/workflow/nodes/card/update.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, Optional, AsyncIterator
 from pydantic import BaseModel, Field
+from sqlalchemy.orm.attributes import flag_modified
 
 from app.services.workflow.nodes.base import BaseNode
 from app.services.workflow.registry import register_node
@@ -76,6 +77,7 @@ class CardUpdateNode(BaseNode):
         # 深度合并内容
         if input_data.content_merge:
             card.content = self._deep_merge(card.content or {}, input_data.content_merge)
+            flag_modified(card, "content")
         
         # 保存
         self.context.session.add(card)


### PR DESCRIPTION
fix:灵感助手生成字段未正确更新章节正文
根因：SQLAlchemy 的 JSON 字段在被修改时，必须显式调用 flag_modified(card, "content") 来标记字段已变更，否则 ORM 无法检测到嵌套字典的修改