### PR TITLE
修复工作流引擎四个已知问题

### DIFF
--- a/backend/app/api/endpoints/workflows.py
+++ b/backend/app/api/endpoints/workflows.py
@@ -64,12 +64,10 @@ from app.services.workflow import (
     get_all_node_metadata,
     RunManager
 )
+from app.services.workflow.engine.run_manager import _executors as _running_executors
 
 
 router = APIRouter()
-
-# 全局字典：保存运行中的执行器实例（用于暂停/恢复）
-_running_executors: Dict[int, Any] = {}  # run_id -> AsyncExecutor
 
 
 @router.get("/nodes/types", response_model=NodeTypesResponse)

--- a/backend/app/services/workflow/engine/run_manager.py
+++ b/backend/app/services/workflow/engine/run_manager.py
@@ -133,9 +133,8 @@ class RunManager:
             # 更新状态为运行中
             self.state_manager.update_run_status(run_id, "running")
 
-            # 解析工作流定义
-            definition = workflow.definition_json or {}
-            code = definition.get("code", "")
+            # 读取工作流代码
+            code = workflow.definition_code or ""
 
             if not code:
                 raise ValueError("工作流缺少代码内容")

--- a/backend/app/services/workflow/engine/run_manager.py
+++ b/backend/app/services/workflow/engine/run_manager.py
@@ -8,24 +8,27 @@ from app.db.models import Workflow, WorkflowRun
 from .state_manager import StateManager
 from .scheduler import WorkflowScheduler
 
+# 进程级共享状态，所有 RunManager 实例共用
+_scheduler = WorkflowScheduler(max_concurrent_runs=5)
+_executors: Dict[int, Any] = {}  # run_id -> AsyncExecutor
+
 
 class RunManager:
     """工作流运行管理器
-    
+
     职责：
     - 创建和启动运行
     - 管理运行生命周期
     - 提供暂停/恢复/取消接口
     - 协调各个组件
-    
+
     只支持代码式工作流系统。
+    scheduler 和 executors 是进程级单例，跨请求共享。
     """
-    
+
     def __init__(self, session: Session):
         self.session = session
         self.state_manager = StateManager(session)
-        self.scheduler = WorkflowScheduler(max_concurrent_runs=5)
-        self.executors: Dict[int, AsyncExecutor] = {}  # 保存执行器引用（用于暂停/恢复）
     
     def create_run(
         self,
@@ -116,7 +119,7 @@ class RunManager:
         executor_coro = self._execute_run(run, workflow)
         
         # 调度执行
-        await self.scheduler.schedule_run(run_id, executor_coro, priority)
+        await _scheduler.schedule_run(run_id, executor_coro, priority)
     
     async def _execute_run(
         self,
@@ -164,7 +167,7 @@ class RunManager:
             )
             
             # 保存执行器引用（用于暂停/恢复）
-            self.executors[run_id] = executor
+            _executors[run_id] = executor
             
             try:
                 # 消费所有事件（触发器场景不需要处理进度）
@@ -175,8 +178,8 @@ class RunManager:
                 result_context = executor.context
             finally:
                 # 清理执行器引用
-                if run_id in self.executors:
-                    del self.executors[run_id]
+                if run_id in _executors:
+                    del _executors[run_id]
 
             # 更新状态为成功
             self.state_manager.update_run_status(
@@ -212,7 +215,7 @@ class RunManager:
             是否成功取消
         """
         # 尝试从调度器取消
-        if self.scheduler.cancel_run(run_id):
+        if _scheduler.cancel_run(run_id):
             self.state_manager.update_run_status(run_id, "cancelled")
             logger.info(f"[RunManager] 运行已取消: run_id={run_id}")
             return True
@@ -228,13 +231,13 @@ class RunManager:
         Returns:
             是否成功暂停
         """
-        executor = self.executors.get(run_id)
+        executor = _executors.get(run_id)
         if executor:
             executor.pause()
             self.state_manager.update_run_status(run_id, "paused")
             logger.info(f"[RunManager] 运行已暂停: run_id={run_id}")
             return True
-        
+
         logger.warning(f"[RunManager] 无法暂停运行（执行器不存在）: run_id={run_id}")
         return False
     
@@ -257,7 +260,7 @@ class RunManager:
             return False
         
         # 检查执行器是否存在
-        executor = self.executors.get(run_id)
+        executor = _executors.get(run_id)
         if executor:
             # 执行器存在，直接恢复
             executor.resume()

--- a/backend/app/services/workflow/engine/scheduler.py
+++ b/backend/app/services/workflow/engine/scheduler.py
@@ -1,26 +1,26 @@
 """工作流调度器 - 管理工作流运行队列"""
 
 import asyncio
-from typing import Dict, Optional
+from typing import Dict, List, Tuple, Any
 from loguru import logger
-
-from app.db.models import WorkflowRun
 
 
 class WorkflowScheduler:
     """工作流调度器
-    
+
     职责：
     - 管理运行队列
     - 控制并发运行数
-    - 优先级调度
+    - 优先级调度（数字越小优先级越高）
     """
-    
+
     def __init__(self, max_concurrent_runs: int = 5):
         self.max_concurrent_runs = max_concurrent_runs
         self.running_runs: Dict[int, asyncio.Task] = {}  # run_id -> task
-        self.pending_queue: asyncio.Queue = asyncio.Queue()  # (priority, run_id)
-    
+        # 用列表模拟优先级队列，入队后按 priority 排序取出
+        self._pending: List[Tuple[int, int, Any]] = []  # [(priority, run_id, coro), ...]
+        self._cancelled_ids: set = set()  # 被取消的排队 run_id
+
     async def schedule_run(
         self,
         run_id: int,
@@ -28,7 +28,7 @@ class WorkflowScheduler:
         priority: int = 0
     ) -> None:
         """调度工作流运行
-        
+
         Args:
             run_id: 运行ID
             executor_coro: 执行器协程
@@ -43,16 +43,18 @@ class WorkflowScheduler:
                 f"[Scheduler] 运行加入等待队列: run_id={run_id}, "
                 f"priority={priority}"
             )
-            await self.pending_queue.put((priority, run_id, executor_coro))
-    
+            self._pending.append((priority, run_id, executor_coro))
+            # 按 priority 升序排列（越小越优先）
+            self._pending.sort(key=lambda x: x[0])
+
     async def _start_run(self, run_id: int, executor_coro) -> None:
         """启动运行"""
         logger.info(f"[Scheduler] 启动运行: run_id={run_id}")
-        
+
         # 创建任务
         task = asyncio.create_task(self._run_with_cleanup(run_id, executor_coro))
         self.running_runs[run_id] = task
-    
+
     async def _run_with_cleanup(self, run_id: int, executor_coro) -> None:
         """执行运行并清理"""
         try:
@@ -61,54 +63,65 @@ class WorkflowScheduler:
             # 清理
             if run_id in self.running_runs:
                 del self.running_runs[run_id]
-            
+
             logger.info(
                 f"[Scheduler] 运行完成: run_id={run_id}, "
                 f"当前运行数={len(self.running_runs)}"
             )
-            
+
             # 启动队列中的下一个
             await self._start_next_from_queue()
-    
+
     async def _start_next_from_queue(self) -> None:
-        """从队列中启动下一个运行"""
-        if self.pending_queue.empty():
+        """从队列中启动下一个运行（按优先级顺序）"""
+        while self._pending and len(self.running_runs) < self.max_concurrent_runs:
+            priority, run_id, executor_coro = self._pending.pop(0)
+
+            # 跳过已被取消的
+            if run_id in self._cancelled_ids:
+                self._cancelled_ids.discard(run_id)
+                logger.info(f"[Scheduler] 跳过已取消的排队运行: run_id={run_id}")
+                continue
+
+            logger.info(
+                f"[Scheduler] 从队列启动运行: run_id={run_id}, priority={priority}"
+            )
+            await self._start_run(run_id, executor_coro)
             return
-        
-        if len(self.running_runs) >= self.max_concurrent_runs:
-            return
-        
-        # 获取优先级最高的运行
-        priority, run_id, executor_coro = await self.pending_queue.get()
-        logger.info(
-            f"[Scheduler] 从队列启动运行: run_id={run_id}, priority={priority}"
-        )
-        await self._start_run(run_id, executor_coro)
-    
+
     def cancel_run(self, run_id: int) -> bool:
-        """取消运行
-        
+        """取消运行（支持取消运行中和排队中的任务）
+
         Args:
             run_id: 运行ID
-            
+
         Returns:
             是否成功取消
         """
+        # 先尝试取消正在运行的
         if run_id in self.running_runs:
             task = self.running_runs[run_id]
             task.cancel()
-            logger.info(f"[Scheduler] 取消运行: run_id={run_id}")
+            logger.info(f"[Scheduler] 取消运行中的任务: run_id={run_id}")
             return True
+
+        # 再尝试取消排队中的
+        for item in self._pending:
+            if item[1] == run_id:
+                self._cancelled_ids.add(run_id)
+                logger.info(f"[Scheduler] 取消排队中的任务: run_id={run_id}")
+                return True
+
         return False
-    
+
     def get_running_count(self) -> int:
         """获取当前运行数"""
         return len(self.running_runs)
-    
+
     def get_pending_count(self) -> int:
         """获取等待队列长度"""
-        return self.pending_queue.qsize()
-    
+        return len(self._pending)
+
     def is_running(self, run_id: int) -> bool:
         """检查运行是否正在执行"""
         return run_id in self.running_runs

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "novelforge",
   "private": true,
   "scripts": {
-    "dev": "start \"Backend\" powershell -NoExit -Command \"python backend/main.py\" && start \"Frontend\" powershell -NoExit -Command \"Start-Sleep -Seconds 5; npm --prefix frontend run dev\""
+    "dev": "node scripts/dev.mjs"
   }
 }

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,75 @@
+/**
+ * Cross-platform dev startup script.
+ *
+ * Starts the backend (uvicorn) and frontend (electron-vite) in parallel,
+ * prefixing their output so you can tell them apart in one terminal.
+ *
+ * Works on macOS, Linux and Windows (Node >= 14).
+ */
+
+import { spawn } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+function run(label, cmd, args, cwd) {
+  const child = spawn(cmd, args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: true,
+  });
+
+  const prefix = `[${label}]`;
+
+  child.stdout.on("data", (data) => {
+    for (const line of data.toString().split("\n")) {
+      if (line) process.stdout.write(`${prefix} ${line}\n`);
+    }
+  });
+
+  child.stderr.on("data", (data) => {
+    for (const line of data.toString().split("\n")) {
+      if (line) process.stderr.write(`${prefix} ${line}\n`);
+    }
+  });
+
+  child.on("close", (code) => {
+    console.log(`${prefix} exited with code ${code}`);
+  });
+
+  return child;
+}
+
+// Detect python command (prefer venv if present)
+const isWin = process.platform === "win32";
+const venvPython = isWin
+  ? resolve(root, "backend", ".venv", "Scripts", "python.exe")
+  : resolve(root, "backend", ".venv", "bin", "python");
+
+// Use venv python if it exists, otherwise fall back to system python
+import { existsSync } from "node:fs";
+const pythonCmd = existsSync(venvPython) ? venvPython : "python3";
+
+const backend = run(
+  "backend",
+  pythonCmd,
+  ["main.py"],
+  resolve(root, "backend")
+);
+
+const frontend = run(
+  "frontend",
+  "npm",
+  ["run", "dev"],
+  resolve(root, "frontend")
+);
+
+// Forward SIGINT / SIGTERM to children
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => {
+    backend.kill(sig);
+    frontend.kill(sig);
+  });
+}


### PR DESCRIPTION
## Summary

修复 Codex 审计发现的四个工作流引擎问题：

- **High**: `RunManager._execute_run()` 读取已失效的 `definition_json` 字段，导致所有工作流执行报"工作流缺少代码内容"，改为读取 `definition_code`
- **High**: `RunManager` 的 `scheduler` 和 `executors` 是实例属性，每次 API 请求都会新建，导致 cancel/pause/resume 跨请求失效、`max_concurrent_runs` 形同虚设，改为模块级单例
- **Medium**: 调度器声称支持优先级调度但实际用的是 FIFO 的 `asyncio.Queue`，且排队中的任务无法取消，改为按 priority 排序的列表并支持取消排队任务
- **Medium**: 根目录 `npm run dev` 写死了 Windows 的 `start`/`powershell`，macOS/Linux 无法运行，改为跨平台的 Node.js 脚本

## Test plan

- [ ] 创建工作流并执行，验证不再报"工作流缺少代码内容"
- [ ] 启动工作流后，通过 cancel API 取消，验证能正确取消
- [ ] 在 macOS 下运行根目录 `npm run dev`，验证前后端均正常启动
- [ ] 在 Windows 下运行根目录 `npm run dev`，验证前后端均正常启动

🤖 Generated with [Claude Code](https://claude.com/claude-code)