### PR TITLE
feat(提示词/知识库): 添加内置项状态显示与重置功能

### DIFF
--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -50,4 +50,18 @@ def delete_knowledge(kid: int, session: Session = Depends(get_session)):
     ok = svc.delete(kid)
     if not ok:
         raise HTTPException(status_code=404, detail='知识库不存在')
-    return ApiResponse(message='删除成功') 
+    return ApiResponse(message='删除成功')
+
+@router.post('/{kid}/reset', response_model=ApiResponse[KnowledgeRead], summary='重置内置知识库')
+def reset_knowledge_endpoint(kid: int, session: Session = Depends(get_session)):
+    """
+    重置内置知识库到原始状态。
+    """
+    svc = KnowledgeService(session)
+    try:
+        item = svc.reset(kid)
+        if not item:
+            raise HTTPException(status_code=404, detail='知识库不存在')
+        return ApiResponse(data=item)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) 

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -34,10 +34,13 @@ def get_knowledge(kid: int, session: Session = Depends(get_session)):
 @router.put('/{kid}', response_model=ApiResponse[KnowledgeRead], summary='更新知识库')
 def update_knowledge(kid: int, body: KnowledgeUpdate, session: Session = Depends(get_session)):
     svc = KnowledgeService(session)
-    item = svc.update(kid, name=body.name, description=body.description, content=body.content)
-    if not item:
-        raise HTTPException(status_code=404, detail='知识库不存在')
-    return ApiResponse(data=item)
+    try:
+        item = svc.update(kid, name=body.name, description=body.description, content=body.content)
+        if not item:
+            raise HTTPException(status_code=404, detail='知识库不存在')
+        return ApiResponse(data=item)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 @router.delete('/{kid}', response_model=ApiResponse, summary='删除知识库')
 def delete_knowledge(kid: int, session: Session = Depends(get_session)):

--- a/backend/app/api/endpoints/prompts.py
+++ b/backend/app/api/endpoints/prompts.py
@@ -78,4 +78,21 @@ def delete_prompt(
         raise HTTPException(status_code=400, detail="系统内置提示词不可删除")
     if not prompt_service.delete_prompt(session=session, prompt_id=prompt_id):
         raise HTTPException(status_code=404, detail="提示词未找到")
-    return ApiResponse(message="提示词删除成功") 
+    return ApiResponse(message="提示词删除成功")
+
+@router.post("/{prompt_id}/reset", response_model=ApiResponse[PromptRead], summary="重置内置提示词")
+def reset_prompt_endpoint(
+    *,
+    session: Session = Depends(get_session),
+    prompt_id: int,
+):
+    """
+    重置内置提示词到原始状态。
+    """
+    try:
+        result = prompt_service.reset_prompt(session=session, prompt_id=prompt_id)
+        if not result:
+            raise HTTPException(status_code=404, detail="提示词未找到")
+        return ApiResponse(data=result)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) 

--- a/backend/app/api/endpoints/prompts.py
+++ b/backend/app/api/endpoints/prompts.py
@@ -57,10 +57,13 @@ def update_prompt(
     """
     更新一个已存在的提示词模板。
     """
-    updated_prompt = prompt_service.update_prompt(session=session, prompt_id=prompt_id, prompt_update=prompt)
-    if not updated_prompt:
-        raise HTTPException(status_code=404, detail="提示词未找到")
-    return ApiResponse(data=updated_prompt)
+    try:
+        updated_prompt = prompt_service.update_prompt(session=session, prompt_id=prompt_id, prompt_update=prompt)
+        if not updated_prompt:
+            raise HTTPException(status_code=404, detail="提示词未找到")
+        return ApiResponse(data=updated_prompt)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 @router.delete("/{prompt_id}", response_model=ApiResponse, summary="删除提示词")
 def delete_prompt(

--- a/backend/app/bootstrap/knowledge.py
+++ b/backend/app/bootstrap/knowledge.py
@@ -15,9 +15,9 @@ from .registry import initializer
 @initializer(name="知识库", order=30)
 def init_knowledge(session: Session) -> None:
     """初始化知识库
-    
+
     从 bootstrap/knowledge 目录导入 *.txt 和 *.md 文件。
-    
+
     Args:
         session: 数据库会话
     """
@@ -29,6 +29,7 @@ def init_knowledge(session: Session) -> None:
     existing = {k.name: k for k in session.exec(select(Knowledge)).all()}
     created = 0
     updated = 0
+    patched = 0
     skipped = 0
     overwrite = settings.bootstrap.should_overwrite
 
@@ -45,20 +46,31 @@ def init_knowledge(session: Session) -> None:
             continue
         description = f"预置知识库：{name}"
         if name in existing:
+            kb = existing[name]
             if overwrite:
-                kb = existing[name]
                 kb.content = content
                 kb.description = description
                 kb.built_in = True
+                # 同步更新原始数据（用于重置）
+                kb.original_content = content
+                kb.original_description = description
                 updated += 1
             else:
+                # 即使不覆盖，也要补充 original_* 字段（旧数据迁移）
+                if kb.original_content is None:
+                    kb.original_content = kb.content
+                    kb.original_description = kb.description
+                    patched += 1
                 skipped += 1
         else:
-            session.add(Knowledge(name=name, description=description, content=content, built_in=True))
+            session.add(Knowledge(
+                name=name, description=description, content=content, built_in=True,
+                original_content=content, original_description=description,
+            ))
             created += 1
 
-    if created or updated:
+    if created or updated or patched:
         session.commit()
-        logger.info(f"知识库初始化完成：新增 {created}，更新 {updated}（overwrite={overwrite}，跳过 {skipped}）")
+        logger.info(f"知识库初始化完成：新增 {created}，更新 {updated}，补丁 {patched}（overwrite={overwrite}，跳过 {skipped}）")
     else:
         logger.info(f"知识库已是最新状态（overwrite={overwrite}，跳过 {skipped}）。")

--- a/backend/app/bootstrap/knowledge.py
+++ b/backend/app/bootstrap/knowledge.py
@@ -47,20 +47,20 @@ def init_knowledge(session: Session) -> None:
         description = f"预置知识库：{name}"
         if name in existing:
             kb = existing[name]
+            # 无论是否 overwrite，都将原始快照设为种子文件数据
+            if kb.original_content != content or kb.original_description != description:
+                kb.original_content = content
+                kb.original_description = description
+                patched += 1
+
+            kb.built_in = True
+
             if overwrite:
                 kb.content = content
                 kb.description = description
-                kb.built_in = True
-                # 同步更新原始数据（用于重置）
-                kb.original_content = content
-                kb.original_description = description
+                kb.is_modified = False
                 updated += 1
             else:
-                # 即使不覆盖，也要补充 original_* 字段（旧数据迁移）
-                if kb.original_content is None:
-                    kb.original_content = kb.content
-                    kb.original_description = kb.description
-                    patched += 1
                 skipped += 1
         else:
             session.add(Knowledge(

--- a/backend/app/bootstrap/prompts.py
+++ b/backend/app/bootstrap/prompts.py
@@ -67,8 +67,7 @@ def init_prompts(session: Session) -> None:
         session: 数据库会话
     """
     overwrite = settings.bootstrap.should_overwrite
-    existing_prompts = session.exec(select(Prompt)).all()
-    existing_names = {p.name for p in existing_prompts}
+    existing_prompts = {p.name: p for p in session.exec(select(Prompt)).all()}
 
     all_prompts_data = get_all_prompt_files()
 
@@ -78,26 +77,26 @@ def init_prompts(session: Session) -> None:
     skipped_count = 0
     prompts_to_add = []
 
-    for name, prompt_data in all_prompts_data.items():
-        if name in existing_names:
-            existing_prompt = next(p for p in existing_prompts if p.name == name)
+    for prompt_name, prompt_data in all_prompts_data.items():
+        if prompt_name in existing_prompts:
+            existing_prompt = existing_prompts[prompt_name]
+            # 无论是否 overwrite，都将原始快照设为种子文件数据
+            if existing_prompt.original_template != prompt_data['template'] or existing_prompt.original_description != prompt_data.get('description'):
+                existing_prompt.original_template = prompt_data['template']
+                existing_prompt.original_description = prompt_data.get('description')
+                patched_count += 1
+
+            existing_prompt.built_in = True
+
             if overwrite:
                 existing_prompt.template = prompt_data['template']
                 existing_prompt.description = prompt_data.get('description')
-                existing_prompt.built_in = True
-                # 同步更新原始数据（用于重置）
-                existing_prompt.original_template = prompt_data['template']
-                existing_prompt.original_description = prompt_data.get('description')
+                existing_prompt.is_modified = False
                 updated_count += 1
             else:
-                # 即使不覆盖，也要补充 original_* 字段（旧数据迁移）
-                if existing_prompt.original_template is None:
-                    existing_prompt.original_template = existing_prompt.template
-                    existing_prompt.original_description = existing_prompt.description
-                    patched_count += 1
                 skipped_count += 1
         else:
-            # 创建新提示词时，同时保存原始数据
+            # 创建新提示词时，保存原始数据
             p = Prompt(**prompt_data, built_in=True,
                        original_template=prompt_data['template'],
                        original_description=prompt_data.get('description'))
@@ -109,6 +108,6 @@ def init_prompts(session: Session) -> None:
 
     if new_count > 0 or updated_count > 0 or patched_count > 0:
         session.commit()
-        logger.info(f"提示词更新完成: 新增 {new_count} 个，更新 {updated_count} 个，补丁 {patched_count} 个（overwrite={overwrite}，跳过 {skipped_count} 个）。")
+        logger.info(f"提示词更新完成: 新增 {new_count} 个，更新 {updated_count} 个，补充快照 {patched_count} 个（overwrite={overwrite}，跳过 {skipped_count} 个）。")
     else:
         logger.info(f"所有提示词已是最新状态（overwrite={overwrite}，跳过 {skipped_count} 个）。")

--- a/backend/app/bootstrap/prompts.py
+++ b/backend/app/bootstrap/prompts.py
@@ -58,11 +58,11 @@ def get_all_prompt_files() -> dict:
 @initializer(name="提示词", order=10)
 def init_prompts(session: Session) -> None:
     """初始化默认提示词
-    
+
     行为受配置项 BOOTSTRAP_OVERWRITE 控制：
     - True: 覆盖更新已存在的提示词
     - False: 跳过已存在的提示词
-    
+
     Args:
         session: 数据库会话
     """
@@ -74,28 +74,41 @@ def init_prompts(session: Session) -> None:
 
     new_count = 0
     updated_count = 0
+    patched_count = 0
     skipped_count = 0
     prompts_to_add = []
-    
+
     for name, prompt_data in all_prompts_data.items():
         if name in existing_names:
+            existing_prompt = next(p for p in existing_prompts if p.name == name)
             if overwrite:
-                existing_prompt = next(p for p in existing_prompts if p.name == name)
                 existing_prompt.template = prompt_data['template']
                 existing_prompt.description = prompt_data.get('description')
                 existing_prompt.built_in = True
+                # 同步更新原始数据（用于重置）
+                existing_prompt.original_template = prompt_data['template']
+                existing_prompt.original_description = prompt_data.get('description')
                 updated_count += 1
             else:
+                # 即使不覆盖，也要补充 original_* 字段（旧数据迁移）
+                if existing_prompt.original_template is None:
+                    existing_prompt.original_template = existing_prompt.template
+                    existing_prompt.original_description = existing_prompt.description
+                    patched_count += 1
                 skipped_count += 1
         else:
-            prompts_to_add.append(Prompt(**prompt_data, built_in=True))
+            # 创建新提示词时，同时保存原始数据
+            p = Prompt(**prompt_data, built_in=True,
+                       original_template=prompt_data['template'],
+                       original_description=prompt_data.get('description'))
+            prompts_to_add.append(p)
             new_count += 1
-    
+
     if prompts_to_add:
         session.add_all(prompts_to_add)
 
-    if new_count > 0 or updated_count > 0:
+    if new_count > 0 or updated_count > 0 or patched_count > 0:
         session.commit()
-        logger.info(f"提示词更新完成: 新增 {new_count} 个，更新 {updated_count} 个（overwrite={overwrite}，跳过 {skipped_count} 个）。")
+        logger.info(f"提示词更新完成: 新增 {new_count} 个，更新 {updated_count} 个，补丁 {patched_count} 个（overwrite={overwrite}，跳过 {skipped_count} 个）。")
     else:
         logger.info(f"所有提示词已是最新状态（overwrite={overwrite}，跳过 {skipped_count} 个）。")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -83,12 +83,20 @@ class Prompt(SQLModel, table=True):
     description: Optional[str] = None
     template: str
     version: int = 1
-    built_in: bool = Field(default=False)
-    is_modified: bool = Field(default=False)
+    built_in: bool = Field(
+        default=False,
+        sa_column=Column(sa.Boolean, nullable=False, server_default=sa.false()),
+    )
+    is_modified: bool = Field(
+        default=False,
+        sa_column=Column(sa.Boolean, nullable=False, server_default=sa.false()),
+    )
     original_template: Optional[str] = None
     original_description: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.now, nullable=False)
-
+    created_at: datetime = Field(
+        default_factory=datetime.now,
+        sa_column=Column(sa.DateTime, nullable=False, server_default=sa.text("'2026-01-01 00:00:00'")),
+    )
 
 
 class CardType(SQLModel, table=True):
@@ -177,11 +185,20 @@ class Knowledge(SQLModel, table=True):
     name: str = Field(unique=True, index=True)
     description: Optional[str] = None
     content: str
-    built_in: bool = Field(default=False)
-    is_modified: bool = Field(default=False)
+    built_in: bool = Field(
+        default=False,
+        sa_column=Column(sa.Boolean, nullable=False, server_default=sa.false()),
+    )
+    is_modified: bool = Field(
+        default=False,
+        sa_column=Column(sa.Boolean, nullable=False, server_default=sa.false()),
+    )
     original_content: Optional[str] = None
     original_description: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.now, nullable=False)
+    created_at: datetime = Field(
+        default_factory=datetime.now,
+        sa_column=Column(sa.DateTime, nullable=False, server_default=sa.text("'2026-01-01 00:00:00'")),
+    )
 
 
 # 工作流系统

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -84,6 +84,10 @@ class Prompt(SQLModel, table=True):
     template: str
     version: int = 1
     built_in: bool = Field(default=False)
+    is_modified: bool = Field(default=False)
+    original_template: Optional[str] = None
+    original_description: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.now, nullable=False)
 
 
 
@@ -174,6 +178,10 @@ class Knowledge(SQLModel, table=True):
     description: Optional[str] = None
     content: str
     built_in: bool = Field(default=False)
+    is_modified: bool = Field(default=False)
+    original_content: Optional[str] = None
+    original_description: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.now, nullable=False)
 
 
 # 工作流系统

--- a/backend/app/schemas/prompt.py
+++ b/backend/app/schemas/prompt.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from datetime import datetime
 
 from sqlmodel import SQLModel, Field
 
@@ -10,6 +11,8 @@ class PromptBase(SQLModel):
 class PromptRead(PromptBase):
     id: int
     built_in: bool = False
+    is_modified: bool = False
+    created_at: Optional[datetime] = None
 
 class PromptCreate(PromptBase):
     pass
@@ -28,6 +31,8 @@ class KnowledgeBase(SQLModel):
 
 class KnowledgeRead(KnowledgeBase):
     id: int
+    is_modified: bool = False
+    created_at: Optional[datetime] = None
 
 class KnowledgeCreate(SQLModel):
     name: str

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -4,14 +4,20 @@ from app.db.models import Knowledge
 
 class KnowledgeService:
     """知识库服务：提供知识库的增删改查。
-    注意：内置（built_in=True）的知识库不允许删除。
+    注意：内置（built_in=True）的知识库不允许删除，但允许编辑和重置。
     """
 
     def __init__(self, db: Session) -> None:
         self.db = db
 
     def list(self, skip: int = 0, limit: int = 200) -> List[Knowledge]:
-        return self.db.exec(select(Knowledge).offset(skip).limit(limit)).all()
+        """获取知识库列表（自定义在前按时间倒序，内置在后）"""
+        return self.db.exec(
+            select(Knowledge)
+            .order_by(Knowledge.built_in.asc(), Knowledge.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+        ).all()
 
     def get_by_id(self, kid: int) -> Optional[Knowledge]:
         return self.db.get(Knowledge, kid)
@@ -36,6 +42,26 @@ class KnowledgeService:
             kb.description = description
         if content is not None:
             kb.content = content
+        # 内置项被编辑时，自动标记为已修改
+        if getattr(kb, 'built_in', False):
+            kb.is_modified = True
+        self.db.add(kb)
+        self.db.commit()
+        self.db.refresh(kb)
+        return kb
+
+    def reset(self, kid: int) -> Optional[Knowledge]:
+        """重置内置知识库到原始状态"""
+        kb = self.get_by_id(kid)
+        if not kb:
+            return None
+        if not getattr(kb, 'built_in', False):
+            raise ValueError("只能重置内置知识库")
+        if kb.original_content is not None:
+            kb.content = kb.original_content
+        if kb.original_description is not None:
+            kb.description = kb.original_description
+        kb.is_modified = False
         self.db.add(kb)
         self.db.commit()
         self.db.refresh(kb)

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -11,13 +11,22 @@ class KnowledgeService:
         self.db = db
 
     def list(self, skip: int = 0, limit: int = 200) -> List[Knowledge]:
-        """获取知识库列表（自定义在前按时间倒序，内置在后）"""
-        return self.db.exec(
+        """获取知识库列表（自定义在前按时间倒序，内置在后；保证内置项始终不被截断）"""
+        custom_stmt = (
             select(Knowledge)
-            .order_by(Knowledge.built_in.asc(), Knowledge.created_at.desc())
+            .where(Knowledge.built_in == False)
+            .order_by(Knowledge.created_at.desc())
             .offset(skip)
             .limit(limit)
-        ).all()
+        )
+        custom_kb = self.db.exec(custom_stmt).all()
+        builtin_stmt = (
+            select(Knowledge)
+            .where(Knowledge.built_in == True)
+            .order_by(Knowledge.created_at.desc())
+        )
+        builtin_kb = self.db.exec(builtin_stmt).all()
+        return list(custom_kb) + list(builtin_kb)
 
     def get_by_id(self, kid: int) -> Optional[Knowledge]:
         return self.db.get(Knowledge, kid)
@@ -36,6 +45,9 @@ class KnowledgeService:
         kb = self.get_by_id(kid)
         if not kb:
             return None
+        if getattr(kb, 'built_in', False):
+            if name is not None and name != kb.name:
+                raise ValueError("系统内置知识库名称不允许修改")
         if name is not None:
             kb.name = name
         if description is not None:
@@ -57,10 +69,10 @@ class KnowledgeService:
             return None
         if not getattr(kb, 'built_in', False):
             raise ValueError("只能重置内置知识库")
-        if kb.original_content is not None:
-            kb.content = kb.original_content
-        if kb.original_description is not None:
-            kb.description = kb.original_description
+        if kb.original_content is None:
+            raise ValueError("该内置知识库缺少原始快照，无法重置")
+        kb.content = kb.original_content
+        kb.description = kb.original_description
         kb.is_modified = False
         self.db.add(kb)
         self.db.commit()

--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -15,14 +15,22 @@ def get_prompt_by_name(session: Session, prompt_name: str) -> Optional[Prompt]:
     return session.exec(statement).first()
 
 def get_prompts(session: Session, skip: int = 0, limit: int = 100) -> List[Prompt]:
-    """获取提示词列表（自定义在前按时间倒序，内置在后）"""
-    statement = (
+    """获取提示词列表（自定义在前按时间倒序，内置在后；保证内置项始终不被截断）"""
+    custom_stmt = (
         select(Prompt)
-        .order_by(Prompt.built_in.asc(), Prompt.created_at.desc())
+        .where(Prompt.built_in == False)
+        .order_by(Prompt.created_at.desc())
         .offset(skip)
         .limit(limit)
     )
-    return session.exec(statement).all()
+    custom_prompts = session.exec(custom_stmt).all()
+    builtin_stmt = (
+        select(Prompt)
+        .where(Prompt.built_in == True)
+        .order_by(Prompt.created_at.desc())
+    )
+    builtin_prompts = session.exec(builtin_stmt).all()
+    return list(custom_prompts) + list(builtin_prompts)
 
 def create_prompt(session: Session, prompt_create: PromptCreate) -> Prompt:
     """创建新提示词"""
@@ -43,6 +51,10 @@ def update_prompt(session: Session, prompt_id: int, prompt_update: PromptUpdate)
     if not db_prompt:
         return None
     prompt_data = prompt_update.model_dump(exclude_unset=True)
+    if getattr(db_prompt, 'built_in', False):
+        new_name = prompt_data.get('name')
+        if new_name is not None and new_name != db_prompt.name:
+            raise ValueError("系统内置提示词名称不允许修改")
     for key, value in prompt_data.items():
         setattr(db_prompt, key, value)
     # 内置项被编辑时，自动标记为已修改
@@ -61,10 +73,10 @@ def reset_prompt(session: Session, prompt_id: int) -> Optional[Prompt]:
         return None
     if not getattr(db_prompt, 'built_in', False):
         raise ValueError("只能重置内置提示词")
-    if db_prompt.original_template is not None:
-        db_prompt.template = db_prompt.original_template
-    if db_prompt.original_description is not None:
-        db_prompt.description = db_prompt.original_description
+    if db_prompt.original_template is None:
+        raise ValueError("该内置提示词缺少原始快照，无法重置")
+    db_prompt.template = db_prompt.original_template
+    db_prompt.description = db_prompt.original_description
     db_prompt.is_modified = False
     session.add(db_prompt)
     session.commit()

--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -15,8 +15,13 @@ def get_prompt_by_name(session: Session, prompt_name: str) -> Optional[Prompt]:
     return session.exec(statement).first()
 
 def get_prompts(session: Session, skip: int = 0, limit: int = 100) -> List[Prompt]:
-    """获取提示词列表"""
-    statement = select(Prompt).offset(skip).limit(limit)
+    """获取提示词列表（自定义在前按时间倒序，内置在后）"""
+    statement = (
+        select(Prompt)
+        .order_by(Prompt.built_in.asc(), Prompt.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
     return session.exec(statement).all()
 
 def create_prompt(session: Session, prompt_create: PromptCreate) -> Prompt:
@@ -40,6 +45,27 @@ def update_prompt(session: Session, prompt_id: int, prompt_update: PromptUpdate)
     prompt_data = prompt_update.model_dump(exclude_unset=True)
     for key, value in prompt_data.items():
         setattr(db_prompt, key, value)
+    # 内置项被编辑时，自动标记为已修改
+    if getattr(db_prompt, 'built_in', False):
+        db_prompt.is_modified = True
+    session.add(db_prompt)
+    session.commit()
+    session.refresh(db_prompt)
+    return db_prompt
+
+
+def reset_prompt(session: Session, prompt_id: int) -> Optional[Prompt]:
+    """重置内置提示词到原始状态"""
+    db_prompt = session.get(Prompt, prompt_id)
+    if not db_prompt:
+        return None
+    if not getattr(db_prompt, 'built_in', False):
+        raise ValueError("只能重置内置提示词")
+    if db_prompt.original_template is not None:
+        db_prompt.template = db_prompt.original_template
+    if db_prompt.original_description is not None:
+        db_prompt.description = db_prompt.original_description
+    db_prompt.is_modified = False
     session.add(db_prompt)
     session.commit()
     session.refresh(db_prompt)

--- a/backend/tests/test_reset_and_bootstrap.py
+++ b/backend/tests/test_reset_and_bootstrap.py
@@ -1,0 +1,251 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from datetime import datetime
+from sqlmodel import SQLModel, Session, create_engine, select, text
+
+from app.db.models import Prompt, Knowledge
+from app.schemas.prompt import PromptUpdate
+from app.services.prompt_service import (
+    get_prompts,
+    update_prompt,
+    reset_prompt,
+)
+from app.services.knowledge_service import KnowledgeService
+from app.bootstrap.prompts import init_prompts
+from app.bootstrap.knowledge import init_knowledge
+from app.core.startup import _ensure_safe_additive_columns
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    # 使用内存 SQLite 数据库进行独立单元测试
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    yield engine
+
+
+@pytest.fixture(name="session")
+def session_fixture(engine):
+    with Session(engine) as session:
+        yield session
+
+
+def test_old_database_column_autofill(monkeypatch):
+    """测试旧数据库升级：缺乏 is_modified, created_at, built_in 列时，启动增量补列成功"""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    
+    # 模拟旧版本数据库（没有 built_in, is_modified, created_at, original_* 列）
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE prompt (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name VARCHAR NOT NULL,
+                description VARCHAR,
+                template VARCHAR NOT NULL,
+                version INTEGER NOT NULL DEFAULT 1
+            );
+        """))
+        conn.execute(text("""
+            CREATE TABLE knowledge (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name VARCHAR NOT NULL,
+                description VARCHAR,
+                content VARCHAR NOT NULL
+            );
+        """))
+        conn.execute(text("""
+            INSERT INTO prompt (name, description, template) VALUES ('old_prompt', 'desc', 'template_v1');
+        """))
+        conn.execute(text("""
+            INSERT INTO knowledge (name, description, content) VALUES ('old_kb', 'desc', 'content_v1');
+        """))
+
+    # 将 app.core.startup.engine 和 app.db.session.engine monkeypatch 为测试内存 engine
+    monkeypatch.setattr("app.core.startup.engine", engine)
+    monkeypatch.setattr("app.db.session.engine", engine)
+    _ensure_safe_additive_columns()
+
+    # 验证补列后可以成功用 SQLModel ORM 完整查出旧数据，无 missing column 异常
+    with Session(engine) as session:
+        prompts = session.exec(select(Prompt)).all()
+        assert len(prompts) == 1
+        assert prompts[0].name == "old_prompt"
+        assert prompts[0].is_modified is False
+        assert isinstance(prompts[0].created_at, datetime)
+
+        kbs = session.exec(select(Knowledge)).all()
+        assert len(kbs) == 1
+        assert kbs[0].name == "old_kb"
+        assert kbs[0].is_modified is False
+        assert isinstance(kbs[0].created_at, datetime)
+
+
+def test_bootstrap_overwrite_modes(session, monkeypatch):
+    """测试 BOOTSTRAP_OVERWRITE 在 True 和 False 下的更新行为"""
+    # 1. 运行初始化 (overwrite=True)
+    monkeypatch.setattr("app.core.config.settings.bootstrap.overwrite", True)
+    init_prompts(session)
+    init_knowledge(session)
+
+    prompt = session.exec(select(Prompt).where(Prompt.built_in == True)).first()
+    assert prompt is not None
+    assert prompt.original_template == prompt.template
+    assert prompt.is_modified is False
+
+    kb = session.exec(select(Knowledge).where(Knowledge.built_in == True)).first()
+    assert kb is not None
+    assert kb.original_content == kb.content
+    assert kb.is_modified is False
+
+    # 2. 用户修改内置项内容
+    prompt.template = "User Modified Template"
+    prompt.is_modified = True
+    session.add(prompt)
+
+    kb.content = "User Modified Content"
+    kb.is_modified = True
+    session.add(kb)
+    session.commit()
+
+    # 3. 模拟在 overwrite=False 下重新启动 Bootstrap
+    monkeypatch.setattr("app.core.config.settings.bootstrap.overwrite", False)
+    init_prompts(session)
+    init_knowledge(session)
+
+    session.refresh(prompt)
+    session.refresh(kb)
+
+    # 校验：overwrite=False 时保留用户修改的 template，但 original_template 保持原始种子快照
+    assert prompt.template == "User Modified Template"
+    assert prompt.original_template != "User Modified Template"
+    assert prompt.is_modified is True
+
+    assert kb.content == "User Modified Content"
+    assert kb.original_content != "User Modified Content"
+    assert kb.is_modified is True
+
+    # 4. 模拟在 overwrite=True 下重新启动 Bootstrap
+    monkeypatch.setattr("app.core.config.settings.bootstrap.overwrite", True)
+    init_prompts(session)
+    init_knowledge(session)
+
+    session.refresh(prompt)
+    session.refresh(kb)
+
+    # 校验：overwrite=True 时覆盖为种子数据，并且 is_modified 被重置为 False
+    assert prompt.template == prompt.original_template
+    assert prompt.is_modified is False
+
+    assert kb.content == kb.original_content
+    assert kb.is_modified is False
+
+
+def test_builtin_edit_and_reset(session):
+    """测试内置项修改与 reset 功能（包括 null 描述情况的还原）"""
+    # 初始化内置提示词和知识库
+    p = Prompt(
+        name="test_builtin_prompt",
+        description=None,  # 原始 description 为 None
+        template="Original Template",
+        original_template="Original Template",
+        original_description=None,
+        built_in=True,
+        is_modified=False,
+    )
+    kb = Knowledge(
+        name="test_builtin_kb",
+        description="Original KB Desc",
+        content="Original Content",
+        original_content="Original Content",
+        original_description="Original KB Desc",
+        built_in=True,
+        is_modified=False,
+    )
+    session.add(p)
+    session.add(kb)
+    session.commit()
+
+    # 修改 Prompt
+    update_prompt(session, p.id, PromptUpdate(description="New Desc", template="New Template"))
+    session.refresh(p)
+    assert p.is_modified is True
+    assert p.template == "New Template"
+    assert p.description == "New Desc"
+
+    # 重置 Prompt
+    reset_prompt(session, p.id)
+    session.refresh(p)
+    assert p.is_modified is False
+    assert p.template == "Original Template"
+    assert p.description is None  # 正确恢复为空（None）而不是保留 New Desc
+
+    # 修改 Knowledge
+    svc = KnowledgeService(session)
+    svc.update(kb.id, description="New KB Desc", content="New Content")
+    session.refresh(kb)
+    assert kb.is_modified is True
+
+    # 重置 Knowledge
+    svc.reset(kb.id)
+    session.refresh(kb)
+    assert kb.is_modified is False
+    assert kb.content == "Original Content"
+    assert kb.description == "Original KB Desc"
+
+
+def test_builtin_rename_prohibited(session):
+    """测试禁止修改内置提示词和内置知识库的名称"""
+    p = Prompt(
+        name="builtin_prompt_fixed",
+        template="Template",
+        built_in=True,
+    )
+    kb = Knowledge(
+        name="builtin_kb_fixed",
+        content="Content",
+        built_in=True,
+    )
+    session.add(p)
+    session.add(kb)
+    session.commit()
+
+    # 尝试修改 Built-in Prompt 名称
+    with pytest.raises(ValueError, match="系统内置提示词名称不允许修改"):
+        update_prompt(session, p.id, PromptUpdate(name="renamed_prompt"))
+
+    # 尝试修改 Built-in Knowledge 名称
+    svc = KnowledgeService(session)
+    with pytest.raises(ValueError, match="系统内置知识库名称不允许修改"):
+        svc.update(kb.id, name="renamed_kb")
+
+
+def test_custom_items_limit_does_not_truncate_builtin(session):
+    """测试自定义项超限时，列表接口仍能完整返回所有内置项"""
+    # 创建 1 个内置 Prompt 和 105 个自定义 Prompt
+    builtin_p = Prompt(name="builtin_p", template="Template", built_in=True)
+    session.add(builtin_p)
+    for i in range(105):
+        session.add(Prompt(name=f"custom_p_{i}", template="Template", built_in=False))
+
+    # 创建 1 个内置 Knowledge 和 105 个自定义 Knowledge
+    builtin_kb = Knowledge(name="builtin_kb", content="Content", built_in=True)
+    session.add(builtin_kb)
+    for i in range(105):
+        session.add(Knowledge(name=f"custom_kb_{i}", content="Content", built_in=False))
+    
+    session.commit()
+
+    # 查询 Prompt 列表 (limit=100)
+    prompts = get_prompts(session, limit=100)
+    # 应包含 100 个自定义项 + 1 个内置项 = 101 项
+    assert len(prompts) == 101
+    assert any(p.name == "builtin_p" for p in prompts)
+
+    # 查询 Knowledge 列表 (limit=100)
+    svc = KnowledgeService(session)
+    kbs = svc.list(limit=100)
+    assert len(kbs) == 101
+    assert any(k.name == "builtin_kb" for k in kbs)

--- a/frontend/src/renderer/src/api/setting.ts
+++ b/frontend/src/renderer/src/api/setting.ts
@@ -21,6 +21,10 @@ export async function updateKnowledge(id: number, body: KnowledgeUpdate): Promis
   return resp
 }
 
+export async function resetKnowledge(id: number): Promise<Knowledge> {
+  return await request.post<Knowledge>(`/knowledge/${id}/reset`, {})
+}
+
 export async function deleteKnowledge(id: number): Promise<{ message: string }> {
   const resp = await request.delete<{ message?: string }>(`/knowledge/${id}`)
   return { message: resp?.message || 'OK' } as any
@@ -121,11 +125,12 @@ export async function copyLLMConfig(id: number): Promise<LLMConfigRead> {
 }
 
 // --- 提示词 API ---
-export interface Prompt { id: number; name: string; description: string; template: string; built_in?: boolean }
+export interface Prompt { id: number; name: string; description: string; template: string; built_in?: boolean; is_modified?: boolean; created_at?: string }
 export async function listPrompts(): Promise<Prompt[]> { return await request.get<Prompt[]>('/prompts') }
 export async function createPrompt(body: Partial<Prompt>): Promise<void> { await request.post('/prompts', body) }
 export async function updatePrompt(id: number, body: Partial<Prompt>): Promise<void> { await request.put(`/prompts/${id}`, body) }
 export async function deletePrompt(id: number): Promise<void> { await request.delete(`/prompts/${id}`) }
+export async function resetPrompt(id: number): Promise<Prompt> { return await request.post<Prompt>(`/prompts/${id}/reset`, {}) }
 
 // --- 卡片类型 API ---
 export type CardTypeRead = components['schemas']['CardTypeRead']

--- a/frontend/src/renderer/src/api/setting.ts
+++ b/frontend/src/renderer/src/api/setting.ts
@@ -125,10 +125,12 @@ export async function copyLLMConfig(id: number): Promise<LLMConfigRead> {
 }
 
 // --- 提示词 API ---
-export interface Prompt { id: number; name: string; description: string; template: string; built_in?: boolean; is_modified?: boolean; created_at?: string }
+export type Prompt = components['schemas']['PromptRead']
+export type PromptCreate = components['schemas']['PromptCreate']
+export type PromptUpdate = components['schemas']['PromptUpdate']
 export async function listPrompts(): Promise<Prompt[]> { return await request.get<Prompt[]>('/prompts') }
-export async function createPrompt(body: Partial<Prompt>): Promise<void> { await request.post('/prompts', body) }
-export async function updatePrompt(id: number, body: Partial<Prompt>): Promise<void> { await request.put(`/prompts/${id}`, body) }
+export async function createPrompt(body: PromptCreate): Promise<void> { await request.post('/prompts', body) }
+export async function updatePrompt(id: number, body: PromptUpdate): Promise<void> { await request.put(`/prompts/${id}`, body) }
 export async function deletePrompt(id: number): Promise<void> { await request.delete(`/prompts/${id}`) }
 export async function resetPrompt(id: number): Promise<Prompt> { return await request.post<Prompt>(`/prompts/${id}/reset`, {}) }
 

--- a/frontend/src/renderer/src/components/setting/CardTypeManager.vue
+++ b/frontend/src/renderer/src/components/setting/CardTypeManager.vue
@@ -39,7 +39,7 @@
     <el-drawer v-model="drawer.visible" :title="drawer.editing ? '编辑卡片类型' : '新增卡片类型'" size="60%">
       <div class="editor-grid">
         <el-form label-position="top" :model="form">
-          <el-form-item label="名称"><el-input v-model="form.name" /></el-form-item>
+          <el-form-item label="名称" required><el-input v-model="form.name" /></el-form-item>
           <el-form-item label="描述"><el-input v-model="form.description" type="textarea" :rows="2" /></el-form-item>
           <el-form-item label="是否启用AI"><el-switch v-model="form.is_ai_enabled" /></el-form-item>
           <el-form-item label="是否单例"><el-switch v-model="form.is_singleton" /></el-form-item>

--- a/frontend/src/renderer/src/components/setting/KnowledgeManager.vue
+++ b/frontend/src/renderer/src/components/setting/KnowledgeManager.vue
@@ -8,19 +8,30 @@
     <el-table :data="items" height="60vh" size="small" v-loading="loading">
       <el-table-column prop="name" label="名称" width="90" />
       <el-table-column prop="description" label="描述" min-width="150" />
-      <el-table-column label="内置" width="80">
+      <el-table-column label="归属" width="120">
         <template #default="{ row }">
-          <el-tag size="small" :type="row.built_in ? 'info' : 'success'">{{ row.built_in ? '内置' : '自定义' }}</el-tag>
+          <el-tag size="small" :type="getOwnershipTagType(row)">
+            {{ getOwnershipLabel(row) }}
+          </el-tag>
         </template>
       </el-table-column>
       <el-table-column label="操作" width="180" align="right">
         <template #default="{ row }">
           <el-button size="small" @click="openEditor(row)">编辑</el-button>
-          <el-popconfirm title="删除该知识？" @confirm="remove(row)">
-            <template #reference>
-              <el-button size="small" type="danger" plain :disabled="row.built_in">删除</el-button>
-            </template>
-          </el-popconfirm>
+          <template v-if="!row.built_in">
+            <el-popconfirm title="删除该知识？" @confirm="remove(row)">
+              <template #reference>
+                <el-button size="small" type="danger" plain>删除</el-button>
+              </template>
+            </el-popconfirm>
+          </template>
+          <template v-else>
+            <el-popconfirm title="重置为原始内容？" @confirm="handleReset(row)">
+              <template #reference>
+                <el-button size="small" type="warning" plain>重置</el-button>
+              </template>
+            </el-popconfirm>
+          </template>
         </template>
       </el-table-column>
     </el-table>
@@ -28,7 +39,7 @@
     <!-- 将抽屉改为模态对话框，避免抽屉内嵌抽屉 -->
     <el-dialog v-model="editor.visible" :title="editor.editing ? '编辑知识' : '新建知识'" width="50%" append-to-body>
       <el-form label-position="top" :model="editor.form">
-        <el-form-item label="名称"><el-input v-model="editor.form.name" :disabled="editor.editing && editor.form.built_in" /></el-form-item>
+        <el-form-item label="名称"><el-input v-model="editor.form.name" /></el-form-item>
         <el-form-item label="描述"><el-input v-model="editor.form.description" type="textarea" :rows="2" /></el-form-item>
         <el-form-item label="内容"><el-input v-model="editor.form.content" type="textarea" :rows="14" /></el-form-item>
       </el-form>
@@ -43,7 +54,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { ElMessage } from 'element-plus'
-import { listKnowledge, createKnowledge, updateKnowledge, deleteKnowledge, type Knowledge } from '@renderer/api/setting'
+import { listKnowledge, createKnowledge, updateKnowledge, deleteKnowledge, resetKnowledge, type Knowledge } from '@renderer/api/setting'
 import { resetKnowledgeOptionCache } from '@renderer/services/knowledgeOptionResolver'
 
 const loading = ref(false)
@@ -66,6 +77,41 @@ function openEditor(row?: Knowledge) {
   editor.value.visible = true
   editor.value.editing = !!row
   editor.value.form = row ? { ...row } : { name: '', description: '', content: '' }
+}
+
+/**
+ * 获取知识库条目的所有权标签类型
+ *
+ */
+function getOwnershipTagType(row: Knowledge): string {
+  if (!row.built_in) return 'success'
+  if (row.is_modified) return 'warning'
+  return 'info'
+}
+
+/**
+ * 获取知识库条目的归属标签
+ */
+function getOwnershipLabel(row: Knowledge): string {
+  if (!row.built_in) return '自定义'
+  if (row.is_modified) return '内置（已修改）'
+  return '内置'
+}
+
+async function handleReset(row: Knowledge) {
+  try {
+    const updated = await resetKnowledge(row.id)
+    resetKnowledgeOptionCache()
+    ElMessage.success('已重置为原始内容')
+    if (updated) {
+      const idx = items.value.findIndex(i => i.id === updated.id)
+      if (idx >= 0) items.value[idx] = updated
+    } else {
+      await fetchList()
+    }
+  } catch (e: any) {
+    ElMessage.error(e?.message || '重置失败')
+  }
 }
 
 async function save() {
@@ -110,4 +156,4 @@ fetchList()
 <style scoped>
 .knowledge-manager { display: flex; flex-direction: column; gap: 12px; height: 100%; }
 .header { display: flex; justify-content: space-between; align-items: center; }
-</style> 
+</style>

--- a/frontend/src/renderer/src/components/setting/KnowledgeManager.vue
+++ b/frontend/src/renderer/src/components/setting/KnowledgeManager.vue
@@ -39,9 +39,9 @@
     <!-- 将抽屉改为模态对话框，避免抽屉内嵌抽屉 -->
     <el-dialog v-model="editor.visible" :title="editor.editing ? '编辑知识' : '新建知识'" width="50%" append-to-body>
       <el-form label-position="top" :model="editor.form">
-        <el-form-item label="名称"><el-input v-model="editor.form.name" /></el-form-item>
+        <el-form-item label="名称" required><el-input v-model="editor.form.name" :disabled="!!editor.form.built_in" /></el-form-item>
         <el-form-item label="描述"><el-input v-model="editor.form.description" type="textarea" :rows="2" /></el-form-item>
-        <el-form-item label="内容"><el-input v-model="editor.form.content" type="textarea" :rows="14" /></el-form-item>
+        <el-form-item label="内容" required><el-input v-model="editor.form.content" type="textarea" :rows="14" /></el-form-item>
       </el-form>
       <template #footer>
         <el-button @click="editor.visible=false">取消</el-button>

--- a/frontend/src/renderer/src/components/setting/PromptWorkshop.vue
+++ b/frontend/src/renderer/src/components/setting/PromptWorkshop.vue
@@ -39,7 +39,7 @@
     <el-drawer v-model="drawerVisible" :title="dialogTitle" size="60%" append-to-body>
       <el-form :model="currentPrompt" label-width="90px" ref="promptForm" class="form-grid">
         <el-form-item label="名称" prop="name" :rules="{ required: true, message: '请输入名称', trigger: 'blur' }">
-          <el-input v-model="currentPrompt.name" />
+          <el-input v-model="currentPrompt.name" :disabled="!!currentPrompt.built_in" />
         </el-form-item>
         <el-form-item label="描述" prop="description">
           <el-input v-model="currentPrompt.description" type="textarea" :rows="2" />

--- a/frontend/src/renderer/src/components/setting/PromptWorkshop.vue
+++ b/frontend/src/renderer/src/components/setting/PromptWorkshop.vue
@@ -7,15 +7,30 @@
     <el-table :data="prompts" style="width: 100%" v-loading="loading">
       <el-table-column prop="name" label="名称" width="180" />
       <el-table-column prop="description" label="描述" />
+      <el-table-column label="归属" width="150">
+        <template #default="{ row }">
+          <el-tag size="small" :type="getOwnershipTagType(row)">
+            {{ getOwnershipLabel(row) }}
+          </el-tag>
+        </template>
+      </el-table-column>
       <el-table-column label="操作" width="220">
         <template #default="{ row }">
           <el-button size="small" @click="handleEdit(row)">编辑</el-button>
-          <el-popconfirm title="删除该提示词？" @confirm="handleDelete(row.id)" v-if="!isBuiltInPrompt(row)">
-            <template #reference>
-              <el-button size="small" type="danger" :disabled="isBuiltInPrompt(row)">删除</el-button>
-            </template>
-          </el-popconfirm>
-          <el-button v-else size="small" type="danger" plain disabled>删除</el-button>
+          <template v-if="!isBuiltInPrompt(row)">
+            <el-popconfirm title="删除该提示词？" @confirm="handleDelete(row.id)">
+              <template #reference>
+                <el-button size="small" type="danger">删除</el-button>
+              </template>
+            </el-popconfirm>
+          </template>
+          <template v-else>
+            <el-popconfirm title="重置为原始内容？" @confirm="handleReset(row.id)">
+              <template #reference>
+                <el-button size="small" type="warning" plain>重置</el-button>
+              </template>
+            </el-popconfirm>
+          </template>
         </template>
       </el-table-column>
     </el-table>
@@ -89,7 +104,7 @@
 import { ref, onMounted, computed } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import type { FormInstance } from 'element-plus'
-import { listKnowledge, type Knowledge, listPrompts, createPrompt, updatePrompt, deletePrompt } from '@renderer/api/setting'
+import { listKnowledge, type Knowledge, listPrompts, createPrompt, updatePrompt, deletePrompt, resetPrompt } from '@renderer/api/setting'
 
 interface Prompt {
   id: number
@@ -97,6 +112,8 @@ interface Prompt {
   description: string
   template: string
   built_in?: boolean
+  is_modified?: boolean
+  created_at?: string
 }
 
 const DEFAULT_OUTPUT_FORMAT = '请严格根据提供的Json Schema返回结果'
@@ -111,6 +128,18 @@ const promptForm = ref<FormInstance>()
 const dialogTitle = computed(() => (currentPrompt.value.id ? '编辑提示词' : '新建提示词'))
 
 const isBuiltInPrompt = (row: Prompt) => !!row.built_in
+
+// 归属状态标签
+function getOwnershipTagType(row: Prompt): string {
+  if (!row.built_in) return 'success'
+  if (row.is_modified) return 'warning'
+  return 'info'
+}
+function getOwnershipLabel(row: Prompt): string {
+  if (!row.built_in) return '自定义'
+  if (row.is_modified) return '内置（已修改）'
+  return '内置'
+}
 
 // 结构化编辑相关
 const useStructured = ref(false)
@@ -288,6 +317,16 @@ async function handleDelete(id: number) {
     if (error !== 'cancel') {
       ElMessage.error('删除失败')
     }
+  }
+}
+
+async function handleReset(id: number) {
+  try {
+    await resetPrompt(id)
+    ElMessage.success('已重置为原始内容')
+    fetchPrompts()
+  } catch (error) {
+    ElMessage.error('重置失败')
   }
 }
 

--- a/frontend/src/renderer/src/types/generated.d.ts
+++ b/frontend/src/renderer/src/types/generated.d.ts
@@ -3053,6 +3053,16 @@ export interface components {
             built_in: boolean;
             /** Id */
             id: number;
+            /**
+             * Is Modified
+             * @default false
+             */
+            is_modified: boolean;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
         };
         /** KnowledgeUpdate */
         KnowledgeUpdate: {
@@ -3387,6 +3397,16 @@ export interface components {
              * @default false
              */
             built_in: boolean;
+            /**
+             * Is Modified
+             * @default false
+             */
+            is_modified: boolean;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
         };
         /** PromptUpdate */
         PromptUpdate: {


### PR DESCRIPTION
Fixes: #148

- 将'内置'列改为'归属'列，支持三状态显示：自定义/内置/内置（已修改）
- 允许编辑内置提示词和知识库，编辑后自动标记为'已修改'
- 内置项的删除按钮改为重置按钮，可一键恢复原始内容
- 自定义项默认按创建时间倒序排列（最新在前），内置项固定在后
- 后端添加 reset API 端点，支持重置到种子数据状态
- 种子数据初始化时保存 original_* 字段用于重置
- Prompt/Knowledge 模型新增 is_modified、original_*、created_at 字段