### PR TITLE
fix: 修复npm v12版本拦截脚本问题

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,5 +84,13 @@
     "vue": "^3.5.13",
     "vue-eslint-parser": "^10.1.3",
     "vue-tsc": "^2.2.8"
+  },
+  "allowScripts": {
+    "electron": true,
+    "esbuild": true,
+    "keytar": true,
+    "@formily/vue": true,
+    "@parcel/watcher": true,
+    "vue-demi": true
   }
 }


### PR DESCRIPTION
## 改动概述

从 npm v12 开始，为了防止供应链攻击，npm 默认会拦截所有第三方依赖包的生命周期安装脚本
在本项目中，会被拦截6个包

<img width="1492" height="1151" alt="image" src="https://github.com/user-attachments/assets/c81c2640-642b-49d1-a437-bc7395a636f3" />

被拦截的 6 个包中包含了非常关键的依赖：
- electron：被拦截后不会自动下载 Electron 二进制运行时，会导致后续无法启动桌面客户端。
- esbuild / keytar / @parcel/watcher：需要执行脚本安装或准备本地平台的原生二进制库。
- vue-demi / @formily/vue：需要执行环境适配脚本。

<img width="1555" height="1066" alt="image" src="https://github.com/user-attachments/assets/968caa91-41cb-4aed-8c10-7eea7529175f" />

## 文件改动说明

仅改动 package.json
将这些可信依赖加入白名单并允许执行它们的脚本

## 验证

<img width="1601" height="1091" alt="image" src="https://github.com/user-attachments/assets/ac4cb737-1dd6-4bcb-bc2e-dc1d45871224" />