### PR TITLE
fix(theme): 修复灵感助手 Markdown 表格与行内代码在暗黑模式下的刺眼问题

### DIFF
--- a/frontend/src/renderer/src/assets/main.css
+++ b/frontend/src/renderer/src/assets/main.css
@@ -99,3 +99,57 @@ body {
 .el-tag {
   border-radius: 4px;
 }
+
+/* XMarkdown / Markdown 全局主题适配 */
+.elx-xmarkdown-container {
+  color: inherit;
+}
+
+.elx-xmarkdown-container table {
+  border-collapse: collapse;
+  width: 100%;
+  border-color: var(--el-border-color-light) !important;
+  margin: 8px 0;
+}
+
+.elx-xmarkdown-container th {
+  background-color: var(--el-fill-color-light) !important;
+  border-color: var(--el-border-color-light) !important;
+  color: var(--el-text-color-primary) !important;
+  font-weight: 600;
+  padding: 8px 12px;
+}
+
+.elx-xmarkdown-container td {
+  border-color: var(--el-border-color-light) !important;
+  color: var(--el-text-color-primary) !important;
+  padding: 8px 12px;
+}
+
+/* 覆盖库中偶数行硬编码的 #fff，使用主题变量 */
+.elx-xmarkdown-container tbody tr:nth-child(2n) {
+  background-color: var(--el-fill-color-lighter) !important;
+}
+
+.elx-xmarkdown-container tbody tr:nth-child(odd) {
+  background-color: transparent !important;
+}
+
+/* 反引号行内代码主题适配 */
+.inline-code-tag {
+  background-color: var(--el-fill-color-light) !important;
+  color: var(--el-text-color-primary) !important;
+  border: 1px solid var(--el-border-color-lighter) !important;
+  border-radius: 4px;
+  padding: 2px 6px !important;
+  margin: 0 2px !important;
+  font-size: 0.88em;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-weight: 500;
+}
+
+html.dark .inline-code-tag {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  color: var(--el-text-color-primary) !important;
+  border-color: rgba(255, 255, 255, 0.12) !important;
+}


### PR DESCRIPTION
Related #171 

## 改动概述

- 在 main.css 中为 XMarkdown 注入 Element Plus 语义化主题变量
- 清理 AgentMessageList.vue 中冗余的 scoped 样式

## 补充

实际上，这个项目使用element-plus-x，作者在2.x 版本把Markdown 核心剥离到了独立仓库 [x-markdown](https://github.com/element-plus-x/x-markdown)

这个新的x-markdown已经修复了样式问题，现在还是beta版本，我就决定自己改写css样式，而不是引入新的依赖了

## 验证

实际效果

<img width="583" height="613" alt="image" src="https://github.com/user-attachments/assets/cc069621-dade-414b-93f5-a471336441e8" />