### PR TITLE
fix: 灵感助手 AI 断连/报错时增加错误感知与自动重试

### DIFF
--- a/backend/app/services/ai/assistant/assistant_service.py
+++ b/backend/app/services/ai/assistant/assistant_service.py
@@ -16,7 +16,7 @@ from sqlmodel import Session
 
 from app.schemas.ai import AssistantChatRequest
 from app.services import llm_config_service
-from app.services.ai.core.chat_model_factory import build_chat_model
+from app.services.ai.core.chat_model_factory import build_chat_model, LLM_CONNECT_MAX_RETRIES
 from app.services.ai.core.quota_manager import precheck_quota, record_usage
 from app.services.ai.core.react_text_agent import stream_chat_with_react_protocol
 from app.services.ai.core.tool_agent_stream import stream_agent_with_tools
@@ -109,6 +109,7 @@ async def stream_chat_plain(
         max_tokens=16384 if request.max_tokens is None else request.max_tokens,
         timeout=request.timeout or 90,
         thinking_enabled=getattr(request, "thinking_enabled", None),
+        max_retries=LLM_CONNECT_MAX_RETRIES,
     )
 
     messages = [

--- a/backend/app/services/ai/core/chat_model_factory.py
+++ b/backend/app/services/ai/core/chat_model_factory.py
@@ -14,12 +14,16 @@ from sqlmodel import Session
 from app.db.models import LLMConfig
 from app.services import llm_config_service
 
+# 连接级瞬时错误（网络抖动、网关 5xx 等）统一重试次数，覆盖各家 provider
+LLM_CONNECT_MAX_RETRIES = 2
+
 
 def _sanitize_common_generation_kwargs(
     *,
     temperature: Optional[float],
     max_tokens: Optional[int],
     timeout: Optional[float],
+    max_retries: Optional[int] = None,
 ) -> dict:
     normalized_max_tokens = None if max_tokens == -1 else max_tokens
     kwargs: dict = {}
@@ -29,6 +33,9 @@ def _sanitize_common_generation_kwargs(
         kwargs["max_tokens"] = int(normalized_max_tokens)
     if timeout is not None:
         kwargs["timeout"] = float(timeout)
+    # None 时保持各 provider SDK 默认重试行为
+    if max_retries is not None:
+        kwargs["max_retries"] = int(max_retries)
     return kwargs
 
 
@@ -62,6 +69,7 @@ def build_chat_model_from_payload(
     max_tokens: Optional[int] = None,
     timeout: Optional[float] = None,
     thinking_enabled: Optional[bool] = None,
+    max_retries: Optional[int] = None,
 ):
     if not api_key:
         raise ValueError("未提供 API Key")
@@ -79,6 +87,7 @@ def build_chat_model_from_payload(
         temperature=temperature,
         max_tokens=max_tokens,
         timeout=timeout,
+        max_retries=max_retries,
     )
 
     if provider_name in {"openai_compatible", "openai"}:
@@ -147,6 +156,7 @@ def build_chat_model(
     max_tokens: Optional[int] = None,
     timeout: Optional[float] = None,
     thinking_enabled: Optional[bool] = None,
+    max_retries: Optional[int] = None,
 ):
     cfg = _get_llm_config(session, llm_config_id)
     return build_chat_model_from_payload(
@@ -162,4 +172,5 @@ def build_chat_model(
         max_tokens=max_tokens,
         timeout=timeout,
         thinking_enabled=thinking_enabled,
+        max_retries=max_retries,
     )

--- a/backend/app/services/ai/core/react_text_agent.py
+++ b/backend/app/services/ai/core/react_text_agent.py
@@ -9,7 +9,7 @@ from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, Sys
 from loguru import logger
 from sqlmodel import Session
 
-from app.services.ai.core.chat_model_factory import build_chat_model
+from app.services.ai.core.chat_model_factory import build_chat_model, LLM_CONNECT_MAX_RETRIES
 from app.services.ai.core.quota_manager import precheck_quota, record_usage
 from app.services.ai.core.token_utils import calc_input_tokens, estimate_tokens
 
@@ -454,6 +454,7 @@ async def stream_chat_with_react_protocol(
         max_tokens=max_tokens,
         timeout=timeout or 90,
         thinking_enabled=thinking_enabled,
+        max_retries=LLM_CONNECT_MAX_RETRIES,
     )
 
     if set_deps is not None:

--- a/backend/app/services/ai/core/tool_agent_stream.py
+++ b/backend/app/services/ai/core/tool_agent_stream.py
@@ -10,7 +10,7 @@ from loguru import logger
 from sqlmodel import Session
 
 from .agent_builder import build_agent
-from .chat_model_factory import build_chat_model
+from .chat_model_factory import build_chat_model, LLM_CONNECT_MAX_RETRIES
 from .quota_manager import precheck_quota, record_usage
 from .token_utils import calc_input_tokens, estimate_tokens
 
@@ -49,6 +49,7 @@ async def stream_agent_with_tools(
         max_tokens=max_tokens,
         timeout=timeout,
         thinking_enabled=thinking_enabled,
+        max_retries=LLM_CONNECT_MAX_RETRIES,
     )
 
     if set_deps is not None:

--- a/frontend/src/renderer/src/components/assistants/AssistantPanel.vue
+++ b/frontend/src/renderer/src/components/assistants/AssistantPanel.vue
@@ -239,7 +239,7 @@ import { useAssistantRequestBuilder } from '@renderer/composables/useAssistantRe
 import { applyAssistantStreamChunk, resetAssistantMessageForRegenerate } from '@renderer/composables/useAssistantStreamMessageOps'
 import { useEnterToSend } from '@renderer/composables/useEnterToSend'
 import { useMessageListScroll } from '@renderer/composables/useMessageListScroll'
-import { notifyTaskDone } from '@renderer/utils/taskDoneNotifier'
+import { notifyTaskDone, notifyTaskFailed } from '@renderer/utils/taskDoneNotifier'
 import type { AssistantChatSession, AssistantPanelMessage } from '@renderer/types/assistantPanel'
 import type { AssistantRef } from '@renderer/api/ai'
 
@@ -250,6 +250,11 @@ const draft = ref('')
 const isStreaming = ref(false)
 let streamCtl: { cancel: () => void } | null = null
 let streamCanceled = false
+// 本次流是否已失败（收到 error 事件 / onError / 看门狗超时），用于 onClose 时区分"完成/失败"通知
+let streamFailedReason: string | null = null
+// 流停滞看门狗：超时未收到任何 chunk 则主动中止。阈值跟随助手超时设置（慢速思考模型需要更长时间）
+const STREAM_STALL_MIN_TIMEOUT_MS = 120_000
+let streamStallTimer: ReturnType<typeof setTimeout> | null = null
 const { messageListRef, scrollToBottom } = useMessageListScroll()
 
 // ---- 多卡片数据引用（跨项目，使用 Pinia） ----
@@ -378,13 +383,20 @@ const assistantPanelStyle = computed(() => ({
   '--nf-assistant-line-height': '1.65',
 }))
 
-function notifyAssistantDone(): void {
-  notifyTaskDone({
-    title: '灵感助手完成',
-    body: '助手回复已生成。',
+function buildNotifyOptions() {
+  return {
     soundEnabled: assistantPrefs.taskDoneSoundEnabled.value,
     desktopNotificationEnabled: assistantPrefs.taskDoneDesktopNotificationEnabled.value,
-  })
+    desktopNotificationMode: assistantPrefs.taskDoneDesktopNotificationMode.value,
+  }
+}
+
+function notifyAssistantDone(): void {
+  notifyTaskDone({ title: '灵感助手完成', body: '助手回复已生成。', ...buildNotifyOptions() })
+}
+
+function notifyAssistantFailed(reason: string): void {
+  notifyTaskFailed({ title: '灵感助手生成失败', body: reason || '生成中断，请重试。', ...buildNotifyOptions() })
 }
 const injectionSelector = useAssistantInjectionSelector({
   assistantStore,
@@ -436,9 +448,56 @@ const { buildConversationText, buildAssistantChatRequest } = useAssistantRequest
   },
 })
 
+function streamStallTimeoutMs(): number {
+  const configured = assistantPrefs.assistantTimeout.value
+  const configuredMs = configured && configured > 0 ? configured * 1000 : 0
+  return Math.max(STREAM_STALL_MIN_TIMEOUT_MS, configuredMs)
+}
+
+function armStreamStallWatchdog(targetIdx: number): void {
+  disarmStreamStallWatchdog()
+  streamStallTimer = setTimeout(() => {
+    streamStallTimer = null
+    if (!isStreaming.value) return
+    // 先捕获句柄：handleStreamFailure 会置空 streamCtl，之后再取消就取不到了
+    const ctl = streamCtl
+    // 标记为已取消：abort 触发的 onClose 走"用户取消"分支，避免重复失败通知
+    streamCanceled = true
+    const stallSeconds = Math.round(streamStallTimeoutMs() / 1000)
+    handleStreamFailure(targetIdx, `生成停滞（${stallSeconds}秒无任何输出），已自动中止。可能是模型服务无响应或网络中断。`)
+    try { ctl?.cancel() } catch {}
+  }, streamStallTimeoutMs())
+}
+
+function disarmStreamStallWatchdog(): void {
+  if (streamStallTimer) {
+    clearTimeout(streamStallTimer)
+    streamStallTimer = null
+  }
+}
+
+function handleStreamFailure(targetIdx: number, reason: string): void {
+  // 已记录的原因优先：后端 error 事件携带的信息比前端网络错误更具体
+  const effectiveReason = streamFailedReason ?? reason
+  streamFailedReason = effectiveReason
+  disarmStreamStallWatchdog()
+
+  const msg = messages.value[targetIdx]
+  if (msg && msg.role === 'assistant') {
+    msg.error = msg.error || effectiveReason
+    msg.toolsInProgress = undefined
+  }
+  isStreaming.value = false
+  streamCtl = null
+
+  saveCurrentSession()
+  notifyAssistantFailed(effectiveReason)
+}
+
 async function startStreaming(targetIdx: number) {
   isStreaming.value = true
   streamCanceled = false
+  streamFailedReason = null
 
   const hasChapterExcerptRefs = assistantStore.injectedRefs.some(ref => ref.refType === 'chapter_excerpt')
   if (hasChapterExcerptRefs) {
@@ -460,6 +519,8 @@ async function startStreaming(targetIdx: number) {
   const promptName = props.promptName?.trim() || '灵感对话'
   const requestTemperature = assistantPrefs.assistantTemperature.value
 
+  // 请求发出即武装看门狗，覆盖 fetch 建连与后端组装首 chunk 的等待期
+  armStreamStallWatchdog(targetIdx)
   streamCtl = generateContinuationStreaming({
     ...chatRequest,
     llm_config_id: overrideLlmId.value || undefined,
@@ -469,6 +530,8 @@ async function startStreaming(targetIdx: number) {
     stream: true,
     thinking_enabled: useThinkingMode.value
   } as any, (chunk) => {
+    // 收到任何 chunk（token/reasoning/tool 事件）即重置停滞看门狗
+    armStreamStallWatchdog(targetIdx)
     applyAssistantStreamChunk({
       messages,
       targetIdx,
@@ -479,14 +542,21 @@ async function startStreaming(targetIdx: number) {
       schedule: callback => nextTick(callback),
       onToolsExecuted: tools => handleToolsExecuted(targetIdx, tools),
     })
+    // 后端异常走 error 事件（onData 路径）：记录失败原因，onClose 时据此改发失败通知
+    const streamedMsg = messages.value[targetIdx]
+    if (streamedMsg?.error && streamFailedReason === null) {
+      streamFailedReason = streamedMsg.error
+    }
   }, () => {
     const wasCanceled = streamCanceled
+    const failedReason = streamFailedReason
     streamCanceled = false
+    streamFailedReason = null
+    disarmStreamStallWatchdog()
     isStreaming.value = false
     streamCtl = null
 
-    if (messages.value[targetIdx]?.toolsInProgress && 
-        !messages.value[targetIdx].toolsInProgress.includes('❌')) {
+    if (messages.value[targetIdx]?.toolsInProgress) {
       nextTick(() => {
         if (messages.value[targetIdx]) {
           messages.value[targetIdx].toolsInProgress = undefined
@@ -498,18 +568,19 @@ async function startStreaming(targetIdx: number) {
       saveCurrentSession()
     }
     if (!wasCanceled) {
-      nfFlushAssistantTextPatchBatches(targetIdx)
-      nfMaybeDispatchTextPatchBatchFromMessage(targetIdx)
-      notifyAssistantDone()
+      if (failedReason) {
+        // 后端异常路径：先收到 error 事件再关闭连接，此前会被误报为"完成"
+        notifyAssistantFailed(failedReason)
+      } else {
+        nfFlushAssistantTextPatchBatches(targetIdx)
+        nfMaybeDispatchTextPatchBatchFromMessage(targetIdx)
+        notifyAssistantDone()
+      }
     }
-  }, (err) => { 
-    streamCanceled = false
-    if (messages.value[targetIdx]) {
-      messages.value[targetIdx].toolsInProgress = undefined
-    }
-    ElMessage.error(err?.message || '生成失败')
-    isStreaming.value = false
-    streamCtl = null 
+  }, (err) => {
+    const reason = err?.message || '生成失败'
+    handleStreamFailure(targetIdx, reason)
+    ElMessage.error(reason)
   }) as any
 }
 
@@ -529,8 +600,11 @@ function handleSend() {
   startStreaming(assistantIdx)
 }
 
-function handleCancel() { 
+function handleCancel() {
   if (streamCtl) streamCanceled = true
+  // 用户主动取消不算失败：解除看门狗并标记已取消，避免 onClose 误判
+  disarmStreamStallWatchdog()
+  streamFailedReason = null
   try { streamCtl?.cancel() } catch {}
   isStreaming.value = false
 
@@ -969,7 +1043,7 @@ function handleToolsExecuted(targetIdx: number, tools: Array<{tool_name: string,
   // 显示通知
   const successTools = tools.filter(t => t.result?.success)
   if (successTools.length > 0) {
-    ElMessage.success(`✅ 已执行 ${successTools.length} 个操作`)
+    ElMessage.success(`已执行 ${successTools.length} 个操作`)
   }
 
   const failedTools = tools.filter(t => t.result?.success === false || t.result?.error)
@@ -1002,6 +1076,7 @@ onBeforeUnmount(() => {
     clearTimeout(saveDebounceTimer)
     saveDebounceTimer = null
   }
+  disarmStreamStallWatchdog()
 })
 </script>
 

--- a/frontend/src/renderer/src/components/editors/CodeMirrorEditor.vue
+++ b/frontend/src/renderer/src/components/editors/CodeMirrorEditor.vue
@@ -2057,6 +2057,7 @@ function notifyEditorTaskDone(kind: EditorTaskDoneKind): void {
 		body,
 		soundEnabled: assistantPrefs.taskDoneSoundEnabled.value,
 		desktopNotificationEnabled: assistantPrefs.taskDoneDesktopNotificationEnabled.value,
+		desktopNotificationMode: assistantPrefs.taskDoneDesktopNotificationMode.value,
 	})
 }
 

--- a/frontend/src/renderer/src/components/setting/AssistantSettings.vue
+++ b/frontend/src/renderer/src/components/setting/AssistantSettings.vue
@@ -6,7 +6,8 @@ import { useAssistantPreferences } from '@renderer/composables/useAssistantPrefe
 import {
   playTaskDoneSound,
   requestTaskDoneNotificationPermission,
-  unlockTaskDoneSound
+  unlockTaskDoneSound,
+  type DesktopNotificationMode,
 } from '@renderer/utils/taskDoneNotifier'
 
 // 通过组合式统一管理灵感助手偏好，方便在设置页与助手面板之间复用
@@ -54,10 +55,10 @@ const taskDoneSoundEnabled = computed({
   }
 })
 
-const taskDoneDesktopNotificationEnabled = computed({
-  get: () => prefs.taskDoneDesktopNotificationEnabled.value,
-  set: (val: boolean) => {
-    void setTaskDoneDesktopNotificationEnabled(val)
+const taskDoneDesktopNotificationMode = computed({
+  get: () => prefs.taskDoneDesktopNotificationMode.value,
+  set: (val: DesktopNotificationMode) => {
+    void setTaskDoneDesktopNotificationMode(val)
   }
 })
 
@@ -79,9 +80,13 @@ async function handleTestTaskDoneSound(): Promise<void> {
   }
 }
 
-async function setTaskDoneDesktopNotificationEnabled(val: boolean): Promise<void> {
-  prefs.setTaskDoneDesktopNotificationEnabled(val)
-  if (!val) return
+async function setTaskDoneDesktopNotificationMode(val: DesktopNotificationMode): Promise<void> {
+  if (val === 'none') {
+    prefs.setTaskDoneDesktopNotificationMode('none')
+    return
+  }
+
+  prefs.setTaskDoneDesktopNotificationMode(val)
 
   const permission = await requestTaskDoneNotificationPermission()
   if (permission === 'granted') {
@@ -89,7 +94,7 @@ async function setTaskDoneDesktopNotificationEnabled(val: boolean): Promise<void
     return
   }
 
-  prefs.setTaskDoneDesktopNotificationEnabled(false)
+  prefs.setTaskDoneDesktopNotificationMode('none')
   if (permission === 'denied') {
     ElMessage.warning('桌面通知权限已被系统或浏览器拒绝，请在系统/浏览器设置中允许通知。')
     return
@@ -235,13 +240,21 @@ async function setTaskDoneDesktopNotificationEnabled(val: boolean): Promise<void
             <el-button size="small" plain @click="handleTestTaskDoneSound">试听提示音</el-button>
           </div>
           <span class="field-hint reminder-hint"
-            >灵感助手、续写、润色、扩写、审阅完成时播放短提示音。</span
+            >灵感助手、续写、润色、扩写、审阅完成或失败时播放提示音（失败为降调音，便于区分）。</span
           >
         </div>
       </el-form-item>
-      <el-form-item label="任务完成后显示桌面通知">
-        <el-switch v-model="taskDoneDesktopNotificationEnabled" />
-        <span class="field-hint">任务完成时显示系统桌面通知，需要系统或浏览器允许通知权限。</span>
+      <el-form-item label="桌面通知策略">
+        <div class="reminder-control">
+          <el-radio-group v-model="taskDoneDesktopNotificationMode" size="small">
+            <el-radio-button label="none">关闭（不提示）</el-radio-button>
+            <el-radio-button label="failed_only">仅失败时提示</el-radio-button>
+            <el-radio-button label="all">完成和失败均提示</el-radio-button>
+          </el-radio-group>
+          <span class="field-hint reminder-hint">
+            灵感助手、续写、润色、扩写、审阅等任务的系统桌面通知触发策略（需要系统或浏览器允许通知权限）。
+          </span>
+        </div>
       </el-form-item>
     </el-form>
   </div>

--- a/frontend/src/renderer/src/components/shared/AgentMessageList.vue
+++ b/frontend/src/renderer/src/components/shared/AgentMessageList.vue
@@ -74,7 +74,22 @@
               </div>
             </div>
 
-            <div v-if="msg.toolsInProgress" class="tools-in-progress">
+            <div v-if="msg.error" class="msg-error-card">
+              <div class="msg-error-head">
+                <span class="msg-error-title">生成失败</span>
+                <el-button
+                  v-if="msg.role === 'assistant' && !props.streaming"
+                  size="small"
+                  type="danger"
+                  plain
+                  :icon="RefreshRight"
+                  @click="emitRegenerateAssistant(idx)"
+                >重试</el-button>
+              </div>
+              <pre class="msg-error-detail">{{ msg.error }}</pre>
+            </div>
+
+            <div v-if="msg.toolsInProgress && !msg.error" class="tools-in-progress">
               <el-icon class="tools-icon spinning"><Loading /></el-icon>
               <pre class="tools-progress-text">{{ msg.toolsInProgress }}</pre>
             </div>
@@ -95,7 +110,7 @@
           v-if="msg.role === 'assistant' && shouldShowAssistantActions(msg, idx)"
           class="assistant-actions"
         >
-          <el-tooltip content="复制回复" placement="top">
+          <el-tooltip v-if="(msg.content || '').trim()" content="复制回复" placement="top">
             <el-button
               circle
               size="small"
@@ -103,7 +118,7 @@
               @click="emitCopyAssistant(idx)"
             />
           </el-tooltip>
-          <el-tooltip content="重新生成" placement="top">
+          <el-tooltip v-if="!msg.error" content="重新生成" placement="top">
             <el-button
               circle
               size="small"
@@ -288,8 +303,8 @@ function formatToolValue(value: unknown): string {
 
 function formatToolStatus(toolItem: any): string {
   const success = toolItem?.result?.success
-  if (success === true) return '✅ 成功'
-  if (success === false) return '❌ 失败'
+  if (success === true) return '成功'
+  if (success === false) return '失败'
   return '已执行'
 }
 
@@ -327,7 +342,9 @@ function isLatestAssistantIndex(index: number): boolean {
 function shouldShowAssistantActions(message: AgentChatMessage, index: number): boolean {
   if (!props.showAssistantActions) return false
   if (message.role !== 'assistant') return false
-  if (!(message.content || '').trim()) return false
+  // 失败的空回复也保留操作按钮（重新生成 = 一键重试）
+  const hasBody = !!(message.content || '').trim() || !!message.error
+  if (!hasBody) return false
   if (props.streaming && index === props.messages.length - 1) return false
   return !props.assistantActionsLatestOnly || isLatestAssistantIndex(index)
 }
@@ -594,6 +611,39 @@ defineExpose({
   padding: 6px 8px;
   border-radius: 8px;
   background: var(--el-fill-color-light);
+}
+
+.msg-error-card {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--el-color-danger-light-5);
+  background: var(--el-color-danger-light-9);
+}
+
+.msg-error-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.msg-error-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-color-danger);
+}
+
+.msg-error-detail {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--el-text-color-regular);
 }
 
 .tools-icon {

--- a/frontend/src/renderer/src/composables/agentChatEvents.ts
+++ b/frontend/src/renderer/src/composables/agentChatEvents.ts
@@ -164,7 +164,7 @@ export function applyAgentStreamEvent(
       target.tools = target.tools || []
       target.tools.push({ tool_name: data.tool_name || 'tool', args: data.args })
     }
-    target.toolsInProgress = `⏳ 正在调用工具: ${data.tool_name || '工具'}...`
+    target.toolsInProgress = `正在调用工具: ${data.tool_name || '工具'}...`
     return
   }
 

--- a/frontend/src/renderer/src/composables/useAgentPreferences.ts
+++ b/frontend/src/renderer/src/composables/useAgentPreferences.ts
@@ -1,4 +1,5 @@
 import { ref, watch } from 'vue'
+import type { DesktopNotificationMode } from '@renderer/utils/taskDoneNotifier'
 
 const STORAGE_KEYS = {
   contextSummaryEnabled: 'nf:agent:ctx_summary_enabled',
@@ -10,6 +11,7 @@ const STORAGE_KEYS = {
   assistantFontSize: 'nf:agent:assistant_font_size',
   taskDoneSoundEnabled: 'nf:agent:task_done_sound_enabled',
   taskDoneDesktopNotificationEnabled: 'nf:agent:task_done_desktop_notification_enabled',
+  taskDoneDesktopNotificationMode: 'nf:agent:task_done_desktop_notification_mode',
 } as const
 
 const LEGACY_KEYS = {
@@ -22,6 +24,7 @@ const LEGACY_KEYS = {
   assistantFontSize: 'nf:assistant:font_size',
   taskDoneSoundEnabled: 'nf:assistant:task_done_sound_enabled',
   taskDoneDesktopNotificationEnabled: 'nf:assistant:task_done_desktop_notification_enabled',
+  taskDoneDesktopNotificationMode: 'nf:assistant:task_done_desktop_notification_mode',
 } as const
 
 const contextSummaryEnabled = ref(false)
@@ -34,6 +37,7 @@ const agentTimeout = ref<number | null>(90)
 const agentAssistantFontSize = ref<number>(16)
 const taskDoneSoundEnabled = ref(false)
 const taskDoneDesktopNotificationEnabled = ref(false)
+const taskDoneDesktopNotificationMode = ref<DesktopNotificationMode>('none')
 
 let initialized = false
 
@@ -50,6 +54,18 @@ function readBoolean(primaryKey: string, legacyKey: string, fallback: boolean): 
   const raw = readRaw(primaryKey) ?? readRaw(legacyKey)
   if (raw == null) return fallback
   return raw === '1' || raw === 'true'
+}
+
+function readDesktopNotificationMode(
+  primaryKey: string,
+  legacyKey: string,
+  fallbackEnabled: boolean,
+): DesktopNotificationMode {
+  const raw = readRaw(primaryKey) ?? readRaw(legacyKey)
+  if (raw === 'none' || raw === 'failed_only' || raw === 'all') {
+    return raw
+  }
+  return fallbackEnabled ? 'all' : 'none'
 }
 
 function readNumber(primaryKey: string, legacyKey: string, fallback: number | null): number | null {
@@ -78,6 +94,15 @@ function readClampedNumber(primaryKey: string, legacyKey: string, fallback: numb
   return Math.min(max, Math.max(min, Math.round(parsed)))
 }
 
+function persistString(primaryKey: string, legacyKey: string, value: string) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(primaryKey, value)
+    window.localStorage.setItem(legacyKey, value)
+  } catch {
+    /* noop */
+  }
+}
 
 function persistBoolean(primaryKey: string, legacyKey: string, value: boolean) {
   if (typeof window === 'undefined') return
@@ -136,11 +161,17 @@ function ensureInitialized() {
     LEGACY_KEYS.taskDoneSoundEnabled,
     false,
   )
-  taskDoneDesktopNotificationEnabled.value = readBoolean(
+  const legacyEnabled = readBoolean(
     STORAGE_KEYS.taskDoneDesktopNotificationEnabled,
     LEGACY_KEYS.taskDoneDesktopNotificationEnabled,
     false,
   )
+  taskDoneDesktopNotificationMode.value = readDesktopNotificationMode(
+    STORAGE_KEYS.taskDoneDesktopNotificationMode,
+    LEGACY_KEYS.taskDoneDesktopNotificationMode,
+    legacyEnabled,
+  )
+  taskDoneDesktopNotificationEnabled.value = taskDoneDesktopNotificationMode.value !== 'none'
 
   watch(contextSummaryEnabled, val => {
     persistBoolean(STORAGE_KEYS.contextSummaryEnabled, LEGACY_KEYS.contextSummaryEnabled, !!val)
@@ -188,11 +219,17 @@ function ensureInitialized() {
     persistBoolean(STORAGE_KEYS.taskDoneSoundEnabled, LEGACY_KEYS.taskDoneSoundEnabled, !!val)
   }, { immediate: true })
 
-  watch(taskDoneDesktopNotificationEnabled, val => {
+  watch(taskDoneDesktopNotificationMode, val => {
+    persistString(
+      STORAGE_KEYS.taskDoneDesktopNotificationMode,
+      LEGACY_KEYS.taskDoneDesktopNotificationMode,
+      val,
+    )
+    taskDoneDesktopNotificationEnabled.value = val !== 'none'
     persistBoolean(
       STORAGE_KEYS.taskDoneDesktopNotificationEnabled,
       LEGACY_KEYS.taskDoneDesktopNotificationEnabled,
-      !!val,
+      val !== 'none',
     )
   }, { immediate: true })
 }
@@ -234,7 +271,13 @@ export function useAgentPreferences() {
     taskDoneSoundEnabled.value = !!val
   }
 
+  function setTaskDoneDesktopNotificationMode(mode: DesktopNotificationMode): void {
+    taskDoneDesktopNotificationMode.value = mode
+    taskDoneDesktopNotificationEnabled.value = mode !== 'none'
+  }
+
   function setTaskDoneDesktopNotificationEnabled(val: boolean): void {
+    taskDoneDesktopNotificationMode.value = val ? 'all' : 'none'
     taskDoneDesktopNotificationEnabled.value = !!val
   }
 
@@ -247,7 +290,7 @@ export function useAgentPreferences() {
     setAgentTimeout(90)
     setAgentAssistantFontSize(16)
     setTaskDoneSoundEnabled(false)
-    setTaskDoneDesktopNotificationEnabled(false)
+    setTaskDoneDesktopNotificationMode('none')
   }
 
   return {
@@ -260,6 +303,7 @@ export function useAgentPreferences() {
     agentAssistantFontSize,
     taskDoneSoundEnabled,
     taskDoneDesktopNotificationEnabled,
+    taskDoneDesktopNotificationMode,
     setContextSummaryEnabled,
     setContextSummaryThreshold,
     setReactModeEnabled,
@@ -269,6 +313,7 @@ export function useAgentPreferences() {
     setAgentAssistantFontSize,
     setTaskDoneSoundEnabled,
     setTaskDoneDesktopNotificationEnabled,
+    setTaskDoneDesktopNotificationMode,
     resetAgentPreferences,
 
     // backward-compatible aliases

--- a/frontend/src/renderer/src/composables/useAssistantStreamMessageOps.ts
+++ b/frontend/src/renderer/src/composables/useAssistantStreamMessageOps.ts
@@ -146,7 +146,7 @@ export function applyAssistantStreamChunk(options: ApplyAssistantStreamChunkOpti
         msg._lastAssistantEvent = 'token'
       }
 
-      if (msg.toolsInProgress && !msg.toolsInProgress.includes('❌')) {
+      if (msg.toolsInProgress && !msg.toolsInProgress.includes('失败')) {
         schedule(() => {
           const latest = options.messages.value[options.targetIdx]
           if (!latest) return
@@ -251,18 +251,20 @@ export function applyAssistantStreamChunk(options: ApplyAssistantStreamChunkOpti
       const reason = data.reason || '工具调用失败'
       const current = data.current ?? data.retry
       const max = data.max
-      baseMessage.toolsInProgress = `🔄 工具调用失败，${reason}，正在重试 (${current}/${max})...`
+      baseMessage.toolsInProgress = `工具调用失败，${reason}，正在重试 (${current}/${max})...`
       options.scrollToBottom()
       return
     }
 
     if (type === 'error') {
-      const errMessage = data.error || '执行失败'
+      const errMessage = data.error || '生成失败'
       applyAgentStreamEvent(baseMessage as any, event as any, {
         trackToolStartInTools: false,
         appendErrorToContent: false,
       })
-      baseMessage.toolsInProgress = `❌ 工具调用失败: ${errMessage}`
+      // 后端所有异常（LLM 断连/超时/配额等）都走此事件，记录真实原因供错误卡片渲染
+      baseMessage.error = errMessage
+      baseMessage.toolsInProgress = undefined
       options.scrollToBottom()
       return
     }
@@ -319,4 +321,5 @@ export function resetAssistantMessageForRegenerate(message: AssistantPanelMessag
   message._hasReasoning = false
   message._reasoningUserToggled = undefined
   message._lastReasoningBucketKey = undefined
+  message.error = undefined
 }

--- a/frontend/src/renderer/src/types/agentChat.ts
+++ b/frontend/src/renderer/src/types/agentChat.ts
@@ -17,6 +17,8 @@ export interface AgentChatMessage {
   reasoning?: string
   toolsInProgress?: string
   timeline?: AgentTimelineItem[]
+  /** 生成失败原因（连接错误/流中断等），用于渲染错误卡片与重试入口 */
+  error?: string
 }
 
 export interface AgentStreamEvent {

--- a/frontend/src/renderer/src/types/assistantPanel.ts
+++ b/frontend/src/renderer/src/types/assistantPanel.ts
@@ -30,6 +30,8 @@ export interface AssistantPanelMessage {
   _hasReasoning?: boolean
   _reasoningUserToggled?: boolean
   _lastReasoningBucketKey?: string
+  /** 生成失败原因（连接错误/流中断等），用于渲染错误卡片与重试入口 */
+  error?: string
 }
 
 export interface AssistantChatSession {

--- a/frontend/src/renderer/src/utils/taskDoneNotifier.ts
+++ b/frontend/src/renderer/src/utils/taskDoneNotifier.ts
@@ -1,5 +1,6 @@
 export type DesktopNotificationPermission = NotificationPermission | 'unsupported'
 export type TaskDoneNotificationPermission = DesktopNotificationPermission
+export type DesktopNotificationMode = 'none' | 'failed_only' | 'all'
 
 export type TaskDoneNotifyOptions = {
   taskId?: string
@@ -9,6 +10,7 @@ export type TaskDoneNotifyOptions = {
   enableDesktopNotification?: boolean
   soundEnabled?: boolean
   desktopNotificationEnabled?: boolean
+  desktopNotificationMode?: DesktopNotificationMode
 }
 
 type AudioContextConstructor = typeof AudioContext
@@ -62,28 +64,32 @@ function safeShowDesktopNotification(title: string, body?: string): void {
   }
 }
 
-export async function warmupDoneSound(): Promise<boolean> {
+let sharedAudioContext: AudioContext | null = null
+
+function getOrCreateAudioContext(): AudioContext | null {
+  if (typeof window === 'undefined') return null
   const AudioContextClass = getAudioContextConstructor()
-  if (!AudioContextClass) return false
-
-  let audioContext: AudioContext | undefined
-
-  try {
-    audioContext = new AudioContextClass()
-
-    if (audioContext.state === 'suspended') {
-      await audioContext.resume()
+  if (!AudioContextClass) return null
+  if (!sharedAudioContext || sharedAudioContext.state === 'closed') {
+    try {
+      sharedAudioContext = new AudioContextClass()
+    } catch {
+      return null
     }
+  }
+  return sharedAudioContext
+}
 
-    return audioContext.state !== 'suspended'
+export async function warmupDoneSound(): Promise<boolean> {
+  try {
+    const ctx = getOrCreateAudioContext()
+    if (!ctx) return false
+    if (ctx.state === 'suspended') {
+      await ctx.resume()
+    }
+    return ctx.state === 'running'
   } catch {
     return false
-  } finally {
-    if (audioContext) {
-      audioContext.close().catch(() => {
-        /* noop */
-      })
-    }
   }
 }
 
@@ -91,84 +97,59 @@ export async function unlockTaskDoneSound(): Promise<boolean> {
   return warmupDoneSound()
 }
 
-function closeAudioContext(audioContext: AudioContext | undefined): void {
-  if (!audioContext) return
-
-  audioContext.close().catch(() => {
-    /* noop */
-  })
-}
-
-function scheduleTone(
-  audioContext: AudioContext,
+function playSingleTone(
+  ctx: AudioContext,
   frequency: number,
   startAt: number,
-  duration: number
+  duration: number,
 ): void {
-  const oscillator = audioContext.createOscillator()
-  const gain = audioContext.createGain()
+  const osc = ctx.createOscillator()
+  const gain = ctx.createGain()
 
-  oscillator.type = 'sine'
-  oscillator.frequency.setValueAtTime(frequency, startAt)
+  osc.type = 'sine'
+  osc.frequency.setValueAtTime(frequency, startAt)
 
+  // 使用平滑稳定的线性渐变包络，避免极端值与时间异常
   gain.gain.setValueAtTime(0.0001, startAt)
-  gain.gain.exponentialRampToValueAtTime(0.8, startAt + 0.018)
-  gain.gain.exponentialRampToValueAtTime(0.0001, startAt + duration)
+  gain.gain.linearRampToValueAtTime(0.35, startAt + 0.02)
+  gain.gain.linearRampToValueAtTime(0.0001, startAt + duration)
 
-  oscillator.connect(gain)
-  gain.connect(audioContext.destination)
-  oscillator.start(startAt)
-  oscillator.stop(startAt + duration + 0.02)
+  osc.connect(gain)
+  gain.connect(ctx.destination)
+
+  osc.start(startAt)
+  osc.stop(startAt + duration + 0.03)
 }
 
-function safePlayDoneSound(): boolean {
-  const AudioContextClass = getAudioContextConstructor()
-  if (!AudioContextClass) return false
+async function safePlayChime(frequencies: [number, number]): Promise<boolean> {
+  try {
+    const ctx = getOrCreateAudioContext()
+    if (!ctx) return false
 
-  let audioContext: AudioContext | undefined
-
-  const playBeep = (): boolean => {
-    if (!audioContext) return false
-
-    try {
-      const now = audioContext.currentTime
-      scheduleTone(audioContext, 880, now, 0.18)
-      scheduleTone(audioContext, 1175, now + 0.2, 0.2)
-
-      window.setTimeout(() => {
-        closeAudioContext(audioContext)
-        audioContext = undefined
-      }, 450)
-      return true
-    } catch {
-      closeAudioContext(audioContext)
-      audioContext = undefined
+    if (ctx.state === 'suspended') {
+      await ctx.resume()
+    }
+    if (ctx.state !== 'running') {
       return false
     }
-  }
 
-  try {
-    audioContext = new AudioContextClass()
-
-    if (audioContext.state === 'suspended') {
-      audioContext
-        .resume()
-        .then(() => {
-          if (audioContext?.state !== 'suspended') playBeep()
-          else closeAudioContext(audioContext)
-        })
-        .catch(() => {
-          closeAudioContext(audioContext)
-          audioContext = undefined
-        })
-      return true
-    }
-
-    return playBeep()
-  } catch {
-    closeAudioContext(audioContext)
+    const now = ctx.currentTime + 0.02
+    playSingleTone(ctx, frequencies[0], now, 0.16)
+    playSingleTone(ctx, frequencies[1], now + 0.18, 0.22)
+    return true
+  } catch (err) {
+    console.warn('[TaskDoneNotifier] 播放提示音失败:', err)
     return false
   }
+}
+
+function safePlayDoneSound(): Promise<boolean> {
+  return safePlayChime([440, 588])
+}
+
+function safePlayFailedSound(): Promise<boolean> {
+  // 降调双音，与完成音（升调）区分
+  return safePlayChime([440, 330])
 }
 
 export async function playTaskDoneSound(): Promise<boolean> {
@@ -187,29 +168,54 @@ function isDuplicateTaskDone(taskId?: string): boolean {
   return false
 }
 
-export function notifyTaskDone(options: TaskDoneNotifyOptions = {}): void {
+/** 共享通知分发：统一去重、声音、桌面通知逻辑 */
+function _dispatchNotification(
+  options: TaskDoneNotifyOptions,
+  defaults: { title: string; duplicatePrefix: string; playSound: () => Promise<boolean>; matchModes: DesktopNotificationMode[] },
+): void {
   try {
     const {
       taskId,
-      title = '任务已完成',
+      title = defaults.title,
       body,
       enableSound,
       enableDesktopNotification,
       soundEnabled,
-      desktopNotificationEnabled
+      desktopNotificationEnabled,
+      desktopNotificationMode,
     } = options
 
-    const duplicateKey = taskId || `${title}\n${body || ''}`
+    const duplicateKey = `${defaults.duplicatePrefix}${taskId || `${title}\n${body || ''}`}`
     if (isDuplicateTaskDone(duplicateKey)) return
 
     if (enableSound ?? soundEnabled ?? false) {
-      safePlayDoneSound()
+      void defaults.playSound()
     }
 
-    if (enableDesktopNotification ?? desktopNotificationEnabled ?? false) {
+    const mode = desktopNotificationMode ?? ((enableDesktopNotification ?? desktopNotificationEnabled) ? 'all' : 'none')
+    if (defaults.matchModes.includes(mode)) {
       safeShowDesktopNotification(title, body)
     }
   } catch {
     /* noop */
   }
 }
+
+export function notifyTaskDone(options: TaskDoneNotifyOptions = {}): void {
+  _dispatchNotification(options, {
+    title: '任务已完成',
+    duplicatePrefix: '',
+    playSound: safePlayDoneSound,
+    matchModes: ['all'],
+  })
+}
+
+export function notifyTaskFailed(options: TaskDoneNotifyOptions = {}): void {
+  _dispatchNotification(options, {
+    title: '任务失败',
+    duplicatePrefix: 'failed:',
+    playSound: safePlayFailedSound,
+    matchModes: ['all', 'failed_only'],
+  })
+}
+


### PR DESCRIPTION
Related #171 

## 改动概述

- 新增流停滞看门狗，超时无输出自动中止并通知
- 错误卡片 UI 展示失败原因，支持一键重试
- LLM 连接级自动重试（网络抖动/5xx 等瞬时错误）
- 失败时播放降调提示音，与完成音区分
- 桌面通知策略改为三档（关闭/仅失败/全部）

## 文件改动说明

### 后端

- **`backend/app/services/ai/core/chat_model_factory.py`** — 新增 `LLM_CONNECT_MAX_RETRIES` 常量定义（唯一来源）；`build_chat_model` 系列函数新增 `max_retries` 参数透传
- **`backend/app/services/ai/assistant/assistant_service.py`** — 删除本地重复常量，改为从 `chat_model_factory` import；`stream_chat_plain` 传入 `max_retries`
- **`backend/app/services/ai/core/react_text_agent.py`** — 同上，删除重复常量；`stream_chat_with_react_protocol` 传入 `max_retries`
- **`backend/app/services/ai/core/tool_agent_stream.py`** — 同上，删除重复常量；`stream_agent_with_tools` 传入 `max_retries`

### 前端 — 核心逻辑

- **`frontend/.../utils/taskDoneNotifier.ts`** — 共享 AudioContext 避免重复创建；新增失败降调提示音；抽取 `_dispatchNotification` 消除 `notifyTaskDone`/`notifyTaskFailed` 重复逻辑；新增 `DesktopNotificationMode` 三档类型；删除冗余 `TaskFailedNotifyOptions` 别名
- **`frontend/.../composables/useAgentPreferences.ts`** — 新增 `taskDoneDesktopNotificationMode` 偏好项（`none`/`failed_only`/`all`）及其读写/持久化逻辑，兼容旧 `taskDoneDesktopNotificationEnabled` 布尔值
- **`frontend/.../composables/useAssistantStreamMessageOps.ts`** — `error` 事件处理改为设置 `msg.error` 字段（取代 `toolsInProgress` 拼接 emoji）；重新生成时清除 `error`
- **`frontend/.../composables/agentChatEvents.ts`** — 工具调用进度文本移除 emoji 前缀

### 前端 — 组件

- **`frontend/.../components/assistants/AssistantPanel.vue`** — 新增流停滞看门狗（`armStreamStallWatchdog`/`disarmStreamStallWatchdog`）；新增 `handleStreamFailure` 统一错误处理；提取 `buildNotifyOptions` 辅助函数精简通知传参；onClose 区分完成/失败通知
- **`frontend/.../components/shared/AgentMessageList.vue`** — 新增错误卡片 UI（`.msg-error-card`）含失败原因与重试按钮；空内容失败消息保留操作栏；工具状态文本移除 emoji
- **`frontend/.../components/setting/AssistantSettings.vue`** — 桌面通知设置从开关改为三档 radio-group；提示音说明文案补充失败场景
- **`frontend/.../components/editors/CodeMirrorEditor.vue`** — 通知调用补充 `desktopNotificationMode` 参数

### 前端 — 类型

- **`frontend/.../types/agentChat.ts`** — `AgentChatMessage` 新增 `error?: string` 字段
- **`frontend/.../types/assistantPanel.ts`** — `AssistantPanelMessage` 新增 `error?: string` 字段

## 验证

<img width="1705" height="1146" alt="image" src="https://github.com/user-attachments/assets/fd856b02-26ac-4063-8d17-4f32460629d0" />


<img width="1491" height="1368" alt="image" src="https://github.com/user-attachments/assets/efdb86ea-6adb-4a67-9c0b-d36abcdfdc09" />
