### PR TITLE
feat(frontend): 行动装置 RWD —— viewport meta 与窄屏抽屉式侧栏

### DIFF
--- a/frontend/src/renderer/index.html
+++ b/frontend/src/renderer/index.html
@@ -2,6 +2,9 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <!-- 移动端必需：没有它浏览器会按 980px 虚拟视口排版再整页缩放，
+         字会变小、触控目标失准，而且所有 max-width 媒体查询都不会触发 -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Novel Forge</title>
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <!--

--- a/frontend/src/renderer/src/composables/useIsMobile.ts
+++ b/frontend/src/renderer/src/composables/useIsMobile.ts
@@ -1,0 +1,27 @@
+import { onBeforeUnmount, readonly, ref } from 'vue'
+
+/** 窄屏断点：低于此宽度时编辑器切换为单栏 + 抽屉式侧栏 */
+export const MOBILE_BREAKPOINT = 900
+
+/**
+ * 响应式的窄屏判断。基于 matchMedia，比监听 resize 省事件也省重排。
+ * 在没有 matchMedia 的环境（SSR / 测试）下固定返回 false。
+ */
+export function useIsMobile() {
+  const isMobile = ref(false)
+
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return { isMobile: readonly(isMobile) }
+  }
+
+  const query = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`)
+  isMobile.value = query.matches
+
+  const onChange = (event: MediaQueryListEvent) => {
+    isMobile.value = event.matches
+  }
+  query.addEventListener('change', onChange)
+  onBeforeUnmount(() => query.removeEventListener('change', onChange))
+
+  return { isMobile: readonly(isMobile) }
+}

--- a/frontend/src/renderer/src/views/Editor.vue
+++ b/frontend/src/renderer/src/views/Editor.vue
@@ -1,7 +1,12 @@
 <template>
-  <div class="editor-layout">
+  <div class="editor-layout" :class="{ 'is-mobile': isMobile }">
     <!-- 左侧卡片导航树 -->
-    <el-aside class="sidebar card-navigation-sidebar" :style="{ width: leftSidebarDisplayWidth + 'px' }" @contextmenu.prevent="onSidebarContextMenu">
+    <el-aside
+      class="sidebar card-navigation-sidebar"
+      :class="{ 'is-drawer': isMobile, 'is-open': isLeftSidebarVisible }"
+      :style="{ width: leftSidebarDisplayWidth + 'px' }"
+      @contextmenu.prevent="onSidebarContextMenu"
+    >
       <div class="sidebar-header">
         <h3 class="sidebar-title">创作卡片</h3>
         
@@ -149,7 +154,7 @@
     </el-aside>
     
     <!-- 拖拽条 -->
-    <div v-if="isLeftSidebarVisible" class="resizer left-resizer" @mousedown="startResizing('left')"></div>
+    <div v-if="isLeftSidebarVisible && !isMobile" class="resizer left-resizer" @mousedown="startResizing('left')"></div>
 
     <!-- 中栏主内容区 -->
     <el-main class="main-content">
@@ -170,8 +175,12 @@
     </el-main>
 
     <!-- 右侧助手面板分隔条与面板 -->
-    <div class="resizer right-resizer" @mousedown="startResizing('right')"></div>
-    <el-aside class="sidebar assistant-sidebar" :style="{ width: rightSidebarWidth + 'px' }">
+    <div v-if="!isMobile" class="resizer right-resizer" @mousedown="startResizing('right')"></div>
+    <el-aside
+      class="sidebar assistant-sidebar"
+      :class="{ 'is-drawer': isMobile, 'is-open': isRightSidebarVisible }"
+      :style="{ width: rightSidebarDisplayWidth + 'px' }"
+    >
       <!-- 章节正文卡片：显示4个Tab -->
       <template v-if="showRightSidebarTabs">
         <el-tabs v-model="activeRightTab" type="card" class="right-tabs">
@@ -247,6 +256,21 @@
         @jump-to-card="handleJumpToCard"
       />
     </el-aside>
+    <!-- 抽屉遮罩：点空白处收起，避免窄屏上侧栏挡住正文出不来 -->
+    <div v-if="isAnyDrawerOpen" class="drawer-backdrop" @click="closeDrawers"></div>
+    <!-- 左抽屉展开时它的把手会滑到右边缘，两颗按钮会叠在一起，所以这时先收起 -->
+    <button
+      v-if="isMobile && !isLeftSidebarVisible"
+      type="button"
+      class="sidebar-edge-toggle sidebar-edge-toggle--right"
+      :class="{ 'is-collapsed': !isRightSidebarVisible }"
+      :aria-label="isRightSidebarVisible ? '收起助手面板' : '展开助手面板'"
+      @click="toggleRightSidebar"
+    >
+      <el-icon class="sidebar-edge-toggle__icon">
+        <component :is="isRightSidebarVisible ? ArrowRight : ArrowLeft" />
+      </el-icon>
+    </button>
     <el-tooltip :content="isLeftSidebarVisible ? '收起左侧导航' : '展开左侧导航'" placement="right">
       <button
         type="button"
@@ -371,6 +395,7 @@ import {
 } from '@element-plus/icons-vue'
 import type { components } from '@renderer/types/generated'
 import { useSidebarResizer } from '@renderer/composables/useSidebarResizer'
+import { useIsMobile } from '@renderer/composables/useIsMobile'
 import AssistantPanel from '@renderer/components/assistants/AssistantPanel.vue'
 import ContextPanel from '@renderer/components/panels/ContextPanel.vue'
 import ChapterToolsPanel from '@renderer/components/panels/ChapterToolsPanel.vue'
@@ -590,12 +615,43 @@ const handleSearch = debounce(async (query: string) => {
 
 // Composables
 const { leftSidebarWidth, rightSidebarWidth, startResizing } = useSidebarResizer()
+const { isMobile } = useIsMobile()
 const isLeftSidebarVisible = ref(true)
-const leftSidebarDisplayWidth = computed(() => (isLeftSidebarVisible.value ? leftSidebarWidth.value : 0))
+// 窄屏时侧栏浮在正文之上（抽屉），默认收起，把整个宽度让给编辑器
+const isRightSidebarVisible = ref(true)
+
+watch(isMobile, (mobile) => {
+  isLeftSidebarVisible.value = !mobile
+  isRightSidebarVisible.value = !mobile
+}, { immediate: true })
+
+// 抽屉模式下宽度不再挤压正文，改为占屏但留一条回到正文的空隙
+const drawerWidth = computed(() => Math.min(window.innerWidth - 48, 360))
+const leftSidebarDisplayWidth = computed(() => {
+  if (isMobile.value) return isLeftSidebarVisible.value ? drawerWidth.value : 0
+  return isLeftSidebarVisible.value ? leftSidebarWidth.value : 0
+})
+const rightSidebarDisplayWidth = computed(() => {
+  if (isMobile.value) return isRightSidebarVisible.value ? drawerWidth.value : 0
+  return rightSidebarWidth.value
+})
 const leftSidebarToggleOffset = computed(() => (isLeftSidebarVisible.value ? Math.max(leftSidebarDisplayWidth.value - 18, 8) : 10))
+const isAnyDrawerOpen = computed(() => isMobile.value && (isLeftSidebarVisible.value || isRightSidebarVisible.value))
 
 function toggleLeftSidebar() {
   isLeftSidebarVisible.value = !isLeftSidebarVisible.value
+  // 两个抽屉同时盖住正文没有意义，开一个就关另一个
+  if (isMobile.value && isLeftSidebarVisible.value) isRightSidebarVisible.value = false
+}
+
+function toggleRightSidebar() {
+  isRightSidebarVisible.value = !isRightSidebarVisible.value
+  if (isMobile.value && isRightSidebarVisible.value) isLeftSidebarVisible.value = false
+}
+
+function closeDrawers() {
+  isLeftSidebarVisible.value = false
+  isRightSidebarVisible.value = false
 }
   
  // 统一 TreeSelect 样式/属性，确保选项可见
@@ -2138,5 +2194,55 @@ function onSwitchRightTab(e: CustomEvent) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/* ===== 窄屏（<=900px）：单栏 + 抽屉式侧栏 =====
+   桌面三栏在手机上会把正文挤到只剩几十像素，这里让两侧浮起来盖在正文之上。 */
+.editor-layout.is-mobile .sidebar.is-drawer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 30;
+  background-color: var(--el-bg-color);
+  box-shadow: 0 0 24px rgba(0, 0, 0, 0.18);
+}
+/* 收起时 width 归零，但 padding 还会把元素撑出 16px 的白条并投下阴影，
+   里面的控件也依然能被 Tab 聚焦；整个藏起来才算真的收起。
+   visibility 延后到宽度收完再切，收起动画才不会突然消失。 */
+.editor-layout.is-mobile .sidebar.is-drawer:not(.is-open) {
+  padding: 0;
+  box-shadow: none;
+  visibility: hidden;
+  transition: width 0.2s, padding 0.2s, box-shadow 0.2s, visibility 0s 0.2s;
+}
+.editor-layout.is-mobile .card-navigation-sidebar.is-drawer {
+  left: 0;
+}
+.editor-layout.is-mobile .assistant-sidebar.is-drawer {
+  right: 0;
+  padding: 8px;
+}
+.editor-layout.is-mobile .main-content {
+  /* 抽屉浮起后正文独占整行 */
+  flex: 1 1 100%;
+  min-width: 0;
+  padding: 8px 4px;
+}
+.drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  background: rgba(0, 0, 0, 0.35);
+}
+.sidebar-edge-toggle--right {
+  right: 10px;
+  left: auto;
+}
+/* 窄屏上把 tab 文字和内边距收紧，避免标签换行把正文高度吃掉 */
+.editor-layout.is-mobile :deep(.el-tabs__item) {
+  padding: 0 10px;
+  font-size: 13px;
+}
+.editor-layout.is-mobile :deep(.el-tabs__content) {
+  padding: 8px;
 }
 </style>


### PR DESCRIPTION
Closes #183

在手机浏览器上打开 NovelForge 时，页面按桌面宽度渲染再整体缩小，三栏布局挤成不可用的状态。这个 PR 让窄屏走一套独立的布局路径。

## 改动

- **`index.html`**：补上 `viewport` meta。移动端改按真实设备宽度排版，同时让原本失效的 `max-width` 媒体查询得以生效。
- **`useIsMobile.ts`**（新增）：基于 `matchMedia` 的组合式函数，断点 900px，随窗口变化响应。
- **`Editor.vue`**：窄屏时从三栏常驻切换为单栏 + 覆盖式抽屉，配遮罩与边缘唤出按钮；触屏上本来就不可用的 resizer 一并隐藏。

## 兼容性

宽屏路径完全不变 —— 新增样式全部挂在 `.is-mobile` 下，桌面端渲染结果与改动前逐像素一致。

